### PR TITLE
docs: add CLAUDE.md, DESIGN.md, TESTING.md; cross-link from README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Personal dotfiles managed by [Chezmoi](https://www.chezmoi.io/), targeting macOS and Linux. Chezmoi renders
+templated files into `$HOME` and runs numbered scripts to install/configure tools. Three package managers, each
+with one job:
+
+```mermaid
+flowchart LR
+    Homebrew["Homebrew\nOS bootstrap, GUI apps,\nBrewfile.system.*/.docker/.gui"] --> Aqua["Aqua\nchecksum-pinned CLI binaries\naqua.yaml"]
+    Homebrew --> Mise["Mise\nlanguage runtimes + npm/pipx tools\nmise/config.toml"]
+    Aqua --> Krew["Krew\nkubectl plugins\nkrew-plugins.txt"]
+```
+
+**Why it's shaped this way, and what secrets/CI/Renovate do**: see [DESIGN.md](DESIGN.md).
+**How to gain confidence in a change**: see [TESTING.md](TESTING.md).
+
+## Repository layout
+
+The tree is organized around *where things deploy to* and *what runs them*, not by tool. Use this to decide
+where a new file belongs — leaf-level detail isn't enumerated here (that's what `ls`/`Glob` is for, and it would
+go stale as scripts are added); this is the stable, abstract shape underneath everything else.
+
+```text
+.
+├── private_dot_*/, private_Library/, dot_*   # actual tool configs, one dir per $HOME target, mirroring
+│                                             # each tool's own on-disk layout (private_dot_config -> ~/.config,
+│                                             # private_dot_local -> ~/.local, dot_bashrc -> ~/.bashrc, ...).
+│                                             # new per-tool config goes here, never under .chezmoiscripts/
+├── .chezmoiscripts/                          # the only place imperative setup logic lives (install/upgrade
+│                                             # tools, generate what can't just be templated). Numeric prefix
+│                                             # = execution order; run_before_* / run_after_* = before/after
+│                                             # dotfiles are written; first-time vs. standard (see DESIGN.md)
+│                                             # are separate files, not a branch in one script
+├── .chezmoitemplates/                        # cross-cutting snippets (env vars, shared shell functions)
+│                                             # included by >1 file in .chezmoiscripts/ — factor duplication
+│                                             # between scripts here, not by copy-pasting between scripts
+├── .first-time-setup/                        # seed config consumed once by the matching first-time script,
+│                                             # then never read again. Not the live config — that's under
+│                                             # private_dot_config/
+└── root-level loose files                    # machine-wide inputs that aren't themselves deployed as
+                                              # dotfiles (Brewfile.*, krew-plugins.txt, .chezmoi.toml.tmpl),
+                                              # or apply to the repo itself rather than to $HOME (lint
+                                              # configs, this doc set)
+```
+
+## Repo-specific constraints when editing templates
+
+- Every `.tmpl` file must render successfully with `.chezmoi.os` forced to `"linux"` and every `bitwardenSecrets`
+  call blanked — that's what CI actually checks (see [TESTING.md](TESTING.md)). Don't write template logic whose
+  only valid path is `darwin` or depends on a real secret value being present.
+- Env vars shared across multiple chezmoi scripts (`AQUA_ROOT_DIR`, `MISE_DATA_DIR`, `HOMEBREW_PREFIX`, etc.) live
+  once in `.chezmoitemplates/*.env` and get pulled in per-script — add new shared vars there rather than
+  redefining them in an individual script.
+
+## Common commands
+
+```bash
+# Apply/re-apply the dotfiles from this source repo
+chezmoi apply --source .
+
+# Pull latest from git and apply in one step (day-to-day usage)
+chezmoi update
+
+# Preview what would change on this machine, without writing anything
+chezmoi diff --source .
+
+# Render a single templated file/script to inspect the output (what CI does before linting)
+chezmoi execute-template --source=. < path/to/file.tmpl
+
+# Repo linters
+pre-commit run --all-files
+shellcheck --rcfile .shellcheckrc <script>
+yamllint --strict <file>.yaml
+markdownlint-cli2 --fix --config .markdownlint-cli2.yaml <file>.md
+dotenv-linter --skip QuoteCharacter <file>
+```
+
+## Secrets
+
+Every credential is pulled via the `bitwardenSecrets` template function keyed by a fixed secret UUID, resolved
+only at `chezmoi apply` time — never hardcoded. See [DESIGN.md](DESIGN.md#secrets-bitwarden-secrets-manager-not-plaintext)
+for why. In practice: `private_dot_env.secrets.tmpl` (API keys, cloud creds, Terraform vars) and
+`.chezmoiscripts/run_after_61_kubeconfig.sh.tmpl` (OIDC client credentials) are the two places new secret
+references get added.
+
+## Renovate
+
+`.github/renovate.json` extends shared presets (`ppat/renovate-presets`, `aquaproj/aqua-renovate-config`) plus a
+custom regex manager for versions pinned in YAML/`.env` comments:
+
+```yaml
+# renovate: datasource=github-releases depName=owner/repo
+SOME_VERSION: "v1.2.3"
+```
+
+Use this pattern for any new tool version embedded directly in workflow YAML (see `CHEZMOI_VERSION` in
+`lint.yaml`). Aqua/Mise-managed tool versions are bumped directly in `aqua.yaml`/`mise/config.toml` instead — do
+not add a `# renovate:` comment for those, Renovate already tracks them natively.
+
+## Commit style
+
+Conventional Commits with a scope, e.g. `fix(cli-tools): update npm:@anthropic-ai/claude-code (2.1.210 ->
+2.1.214)`. Scope names generally match the renovate customManager/preset group the change came from (e.g.
+`cli-tools`, `dev-tools`, `lang-sdk`).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,140 @@
+# DESIGN.md
+
+Intent, trade-offs, and system structure behind this dotfiles repo. For "what do I run" / "how are files named",
+see [CLAUDE.md](CLAUDE.md); for "how do I know a change is safe", see [TESTING.md](TESTING.md).
+
+## Problem being solved
+
+Personal environment configuration across multiple machines (a macOS laptop, Linux dev boxes, homelab nodes) that
+must be:
+
+- reproducible from zero on a fresh machine,
+- safe to re-run repeatedly without re-prompting or clobbering machine-specific state,
+- free of plaintext secrets in git history,
+- cheap to keep current — dependency bumps shouldn't be hand-maintained toil.
+
+## System overview
+
+```mermaid
+flowchart TD
+    subgraph Bootstrap["chezmoi init --apply ppat/dotfiles"]
+        Prompt["prompt once: name, email, bwsAccessToken"]
+    end
+    Prompt --> Render["render every .tmpl\n(.chezmoi.os, .chezmoi.homeDir, bitwardenSecrets)"]
+    Render --> Before["run_before_* scripts\n(homebrew, mise/aqua first-time)"]
+    Before --> Write["write rendered dotfiles to $HOME"]
+    Write --> After["run_after_* scripts\n(mise/aqua standard, krew, docker, completions, kubeconfig)"]
+    After --> OnChange["run_onchange_* scripts\n(macOS defaults, launch agents —\nonly re-run when their own rendered content changes)"]
+
+    Update["chezmoi update\n(day-to-day)"] -.->|git pull, then same pipeline| Render
+```
+
+Chezmoi is the only orchestrator. It isn't a script that happens to call package managers — it *is* the thing
+that decides what runs, in what order, against what rendered template context. Everything downstream (Homebrew,
+Aqua, Mise, Krew) is invoked *by* chezmoi scripts, never the reverse.
+
+## Why three package managers, not one
+
+```mermaid
+flowchart LR
+    subgraph Homebrew["Homebrew — OS-level bootstrap"]
+        H1["baseline system packages\n(git, curl, bash, coreutils...)"]
+        H2["installs aqua + mise themselves"]
+        H3["macOS-only: GUI casks, Docker/Colima"]
+    end
+    subgraph Aqua["Aqua — pinned CLI binaries"]
+        A1["kubectl, helm, gh, flux, yq...\nchecksum-verified, tag-pinned"]
+    end
+    subgraph Mise["Mise — language runtimes"]
+        M1["go, rust, node, terraform\n+ npm/pipx global tools"]
+    end
+    Homebrew --> Aqua
+    Homebrew --> Mise
+    Aqua --> Krew["Krew — kubectl plugins"]
+```
+
+Each tool is used for what it's actually best at, not for uniformity:
+
+- **Homebrew** is the only one of the three that can install itself on a bare OS and that ships macOS GUI apps
+  (casks) — so it's the bootstrap layer, and it stays responsible for anything Aqua/Mise can't do (GUI apps,
+  Colima/Docker on macOS, baseline OS packages like `coreutils`/`gnupg`).
+- **Aqua** enforces checksums (`checksum.require_checksum: true` in `aqua.yaml`) on every install — every CLI
+  binary version is pinned to an exact tag and its release-artifact hash is verified before use. That matters for
+  security-relevant tools (`kubectl`, `helm`, `gh`, cloud CLIs) where supply-chain integrity is the point;
+  Homebrew formulas and Mise's registry don't give the same per-artifact verification.
+- **Mise** owns language runtimes and per-project version switching (`go`, `rust`, `node`, `terraform`), plus a
+  handful of npm/pipx-distributed tools (Claude Code, markdownlint-cli2, ansible-core) that don't have Aqua
+  registry entries. Mise's `[[env]]` file-loading in `private_dot_config/mise/config.toml` is also how this repo
+  gets environment variables into every shell — no chezmoi script is needed for that.
+
+Trade-off accepted: three tools means three update mechanisms and three places dependency drift can hide. This is
+mitigated by giving each tool exactly one job — no package is ever installable through more than one of them —
+and by automating all three through Renovate (below) instead of relying on manual upgrades.
+
+## First-time vs. standard setup
+
+Chezmoi scripts split into `run_before_NN_*` (before dotfiles are written) and `run_after_NN_*` (after). Within
+that, the Aqua and Mise scripts each fork into a `First-Time` path and a `Standard` path (see
+`.chezmoitemplates/script_aqua.sh` / `script_mise.sh`):
+
+- **First-time**: destructive — wipes and reinitializes the tool's global config directory from
+  `.first-time-setup/`, then does a fresh install. Runs once, guarded by a sentinel file
+  (`.first-time-setup-complete`) so it never repeats.
+- **Standard**: idempotent maintenance — upgrades installed packages, then prunes/vacuums anything unused. Safe
+  to run on every `chezmoi update`.
+
+This split exists because a fresh machine and a years-old machine need different things: a fresh machine needs
+its config directory seeded from a known-good state, not whatever partial state a previous half-run left behind,
+while an established machine must never have its config directory wiped just because `chezmoi update` ran again.
+
+## Secrets: Bitwarden Secrets Manager, not plaintext
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ChezmoiToml as .chezmoi.toml.tmpl
+    participant BWS as Bitwarden Secrets Manager
+    participant Rendered as Rendered file (e.g. ~/.env.secrets)
+
+    User->>ChezmoiToml: chezmoi init (first run only)
+    ChezmoiToml->>User: promptStringOnce("bwsAccessToken")
+    Note over ChezmoiToml: token cached in chezmoi config,\nnever committed to git
+    Rendered->>BWS: bitwardenSecrets("<fixed-uuid>", token) at render time
+    BWS-->>Rendered: secret value inlined into the file on disk
+```
+
+Every credential (Anthropic/OpenRouter API keys, cloud creds, Terraform variables, Kubernetes OIDC client
+secrets) is fetched by a fixed secret UUID through the `bitwardenSecrets` template function, resolved only at
+`chezmoi apply` time on the target machine. The repo therefore contains *which* secrets exist and their UUIDs,
+but never a value. That trade-off is deliberate: a leaked UUID list is far less damaging than a leaked value, and
+the UUIDs are useless without a valid `bwsAccessToken`.
+
+It's also why environment config is split across two files instead of one: `private_dot_env.tmpl` holds config
+that's fine to always load (colors, XDG paths, package-manager env), while `private_dot_env.secrets.tmpl` is
+loaded only opportunistically (its `[[env]]` entry is commented out by default in
+`private_dot_config/mise/config.toml`) so secrets aren't pulled into every shell session unless actually needed.
+
+## CI can't be the full story
+
+The lint pipeline (see [TESTING.md](TESTING.md)) renders every template with `.chezmoi.os` forced to `"linux"`
+and every `bitwardenSecrets` call blanked out before linting. That's a deliberate, narrow goal: catch template
+syntax errors and lint the *shape* of rendered output, not validate macOS-only code paths or real secret
+substitution. Those two things can only be proven by `chezmoi apply` on a real machine with a real
+`bwsAccessToken`, which is inherently outside what a shared CI runner can do. CI is a syntax/lint safety net, not
+an end-to-end guarantee.
+
+## Shared CI logic lives in a sibling repo
+
+`.github/workflows/lint.yaml` delegates most of its jobs (Markdown, YAML, shellcheck, GitHub Actions, Renovate
+config, pre-commit) to reusable workflows in `ppat/github-workflows`, pinned by commit SHA. Only the
+chezmoi-specific rendering step is inlined, because it's the one piece of logic unique to how *this* repo's
+templates work. Everything generic is shared and versioned once across this user's repos, and Renovate keeps the
+pinned SHA current — the same automation-over-manual-toil principle applied to CI as to package versions.
+
+## Renovate: one custom manager for template-pinned versions
+
+Aqua and Mise track their own tool versions natively (`aqua.yaml`, `mise/config.toml`), so Renovate's built-in
+managers handle those directly. But tool versions embedded as plain strings inside YAML/`.env` files (e.g.
+`CHEZMOI_VERSION` in `lint.yaml`) aren't a format Renovate understands out of the box. The custom regex manager
+in `.github/renovate.json` closes that narrow gap by keying off a `# renovate: datasource=... depName=...`
+comment convention — one mechanism, used only where the native managers don't reach.

--- a/README.md
+++ b/README.md
@@ -76,3 +76,10 @@ Chezmoi will:
 
 - Fetch latest from git
 - Apply all the updates
+
+## More
+
+- [DESIGN.md](DESIGN.md) — why this repo is structured the way it is: the three-package-manager split,
+  first-time vs. standard setup, secrets handling, and CI/Renovate design.
+- [TESTING.md](TESTING.md) — how a change here is actually verified before merging.
+- [CLAUDE.md](CLAUDE.md) — command reference and conventions for AI coding assistants working in this repo.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,105 @@
+# TESTING.md
+
+There is no unit-test suite — this repo is configuration, not application logic. Confidence in a change comes
+from a **render-then-lint** workflow: every templated file is rendered to what it would actually look like on
+disk, then the rendered output is checked with format-appropriate tools. Static analysis/linting *commands* are
+listed in [CLAUDE.md](CLAUDE.md); this doc describes the actual mechanism — what runs, in what order, against
+what, and what it does and doesn't prove. Design rationale is in [DESIGN.md](DESIGN.md).
+
+## The mechanism, end to end
+
+```mermaid
+flowchart TD
+    PR["pull request"] --> Detect["detect-changed-files\n(scopes jobs to only what changed;\nfull sweep on push/schedule/PR-to-lint.yaml-itself)"]
+
+    Detect --> ChezmoiJob["chezmoi job (inline in lint.yaml)"]
+    Detect --> GHA["github-actions job"]
+    Detect --> MD["markdown job"]
+    Detect --> YAML["yaml job"]
+    Detect --> PreCommit["pre-commit job"]
+    Detect --> Renovate["renovate-config-check job"]
+    Detect --> SC["shellcheck job"]
+
+    subgraph ChezmoiJob_detail[" "]
+        direction TB
+        Patch["sed: force .chezmoi.os -> linux;\nblank out every bitwardenSecrets call"]
+        Patch --> Render["chezmoi execute-template --source=."]
+        Render --> ShellcheckSub["shellcheck --rcfile .shellcheckrc\n(on rendered .chezmoiscripts / private_dot_local/{bash,bin} tmpl output)"]
+        Render --> Dotenv["dotenv-linter --skip QuoteCharacter\n(on rendered private_dot_env*.tmpl output)"]
+    end
+    ChezmoiJob -.-> ChezmoiJob_detail
+```
+
+Each job below is delegated to a reusable workflow in the sibling `ppat/github-workflows` repo, pinned by commit
+SHA — this repo supplies only the file list and its own lint configs (`.shellcheckrc`, `.yamllint`,
+`.markdownlint-cli2.yaml`, `.pre-commit-config.yaml`).
+
+### 1. Change detection scopes the run
+
+A `detect-changed-files` job classifies changed files into buckets (`chezmoiscripts`, `chezmoienv`, `actions`,
+`markdown`, `renovate`, `shellscripts`, `yaml`). On a pull request, each downstream job only runs if its bucket
+has changes, and only lints the changed files in that bucket. On push to `main`, on the weekly schedule
+(`0 5 * * 1`), or on manual dispatch, every job runs against the full repo (`ALL`). This means a PR that only
+touches, say, `krew-plugins.txt` triggers no lint jobs at all — nothing in that bucket maps to a checked file
+type.
+
+### 2. Chezmoi templates: render first, then lint the output — never the template source
+
+This is the one job inlined directly in `.github/workflows/lint.yaml` rather than delegated, because it's the
+only lint step that understands this repo's template syntax.
+
+- Every `.tmpl` file has `"darwin"` string-replaced with `"linux"` and every
+  `{{ (bitwardenSecrets "...".value }}` call replaced with the literal string `fake-test-value`, via `sed`,
+  *before* rendering.
+- `chezmoi execute-template --source=$(pwd)` renders the patched template to what chezmoi would actually write to
+  disk.
+- The rendered `.chezmoiscripts/*` and `private_dot_local/{bash,bin}/*` shell scripts are shellchecked with this
+  repo's `.shellcheckrc`.
+- The rendered `private_dot_env*` files are checked with `dotenv-linter --skip QuoteCharacter`.
+
+What this proves: the template renders without error, and the *shape* of what it produces is valid shell /
+valid dotenv syntax. What it does not prove: that the script behaves correctly with real secret values, or that
+any `{{ if eq .chezmoi.os "darwin" }}` branch works, since that branch is never taken in CI (`.chezmoi.os` is
+always forced to `"linux"`). macOS-only logic and real-secret behavior can only be verified by actually running
+`chezmoi apply` on a real machine with a real Bitwarden token — there is no substitute for that in this repo's CI.
+
+### 3. Everything else is format-level static checking on rendered/plain files
+
+- **shellcheck job** — every executable file in the repo (or just the changed ones on a PR), via
+  `find ... -executable -exec shellcheck --rcfile .shellcheckrc {} +`. This is broader than the chezmoi job's
+  shellcheck pass: it catches plain (non-templated) executables like `private_dot_local/bin/executable_show-env`
+  too.
+- **github-actions job** — `actionlint -shellcheck "shellcheck --rcfile .shellcheckrc"` against
+  `.github/workflows/*.yaml`, which also shellchecks any inline `run:` steps.
+- **markdown job** — `markdownlint-cli2` against `**/*.md` using `.markdownlint-cli2.yaml` (CHANGELOG.md files
+  are excluded when running against a changed-file subset).
+- **yaml job** — `yamllint -c .yamllint --strict` against all `.yaml`/`.yml` files.
+- **renovate-config-check job** — `renovate-config-validator` against `.github/renovate.json` and every file
+  under `.github/renovate/`.
+- **pre-commit job** — installs this repo's `.pre-commit-config.yaml` hooks and runs each one individually
+  against the whole tree: `check-added-large-files`, `check-executables-have-shebangs`, `check-json`,
+  `detect-private-key`, `end-of-file-fixer`, `forbid-new-submodules`, `mixed-line-ending`, `trailing-whitespace`.
+  Note this list is narrower than the full hook set defined in `.pre-commit-config.yaml` — the texthooks,
+  yamllint, shellcheck, and markdownlint-cli2 hooks in that file are exercised locally via
+  `pre-commit run --all-files`, but aren't re-run as individual named CI steps (yamllint/shellcheck/markdownlint
+  are already covered above, by the dedicated jobs, using this repo's own config rather than pre-commit's hook
+  wrapper).
+
+## What gains confidence locally, before pushing
+
+```bash
+# Render a specific template exactly like CI does, to eyeball the output
+sed -i 's|"darwin"|"linux"|; s|{{ (bitwardenSecrets ".*" .bwsAccessToken).value }}|fake-test-value|' /tmp/copy-of-file.tmpl
+chezmoi execute-template --source=. < /tmp/copy-of-file.tmpl
+
+# Preview what a real chezmoi apply would change on this machine, without writing anything
+chezmoi diff --source .
+
+# Run the full local pre-commit hook set (broader than the CI pre-commit job — see above)
+pre-commit run --all-files
+```
+
+`chezmoi diff --source .` is the closest thing this repo has to an integration test: it renders every template
+with this machine's *real* `.chezmoi.toml.tmpl` data (real OS, real secrets if `bwsAccessToken` is configured)
+and shows exactly what would change on disk — the one check that exercises real secret substitution and the real
+OS branch, which CI structurally cannot do.


### PR DESCRIPTION
Add CLAUDE.md as command/convention reference for AI coding assistants: common chezmoi commands, an abstract repository layout (organized by deploy-target and script-role rather than an enumerated file list, to stay stable as scripts are added), template-rendering constraints CI enforces, secrets/Renovate conventions, and commit style.

Add DESIGN.md to capture the intent and trade-offs behind the repo's structure: the chezmoi bootstrap pipeline, why three package managers (Homebrew/Aqua/Mise) each own exactly one job, the first-time-vs-standard script split, the Bitwarden-backed secrets flow, why CI can't validate macOS-only paths or real secrets, and why generic CI logic is delegated to the sibling ppat/github-workflows repo.

Add TESTING.md to document the actual render-then-lint mechanism this repo relies on for confidence (verified against the reusable CI workflow definitions), including what it does and doesn't prove, and what to run locally before pushing.

Cross-link all three from README.md instead of duplicating their content.