### PR TITLE
feat(claude): shellcheck shell scripts automatically on edit

### DIFF
--- a/private_dot_claude/hooks/executable_shellcheck-on-edit.sh
+++ b/private_dot_claude/hooks/executable_shellcheck-on-edit.sh
@@ -1,112 +1,41 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# PostToolUse hook: run shellcheck against a shell script right after Claude edits it, so
-# feedback that would otherwise only arrive from CI on push shows up at edit time instead.
+# PostToolUse hook: shellcheck a shell script right after Claude edits it, in whatever repo
+# Claude happens to be working in. Settings are user-level, so this fires everywhere - the
+# point is to shorten the shellcheck feedback loop generally, not to mirror any one repo's CI.
 #
-# Scope is intentionally the same set of paths lint.yaml's chezmoi/shellcheck jobs already
-# treat as shell scripts (see TESTING.md) - this hook doesn't invent new lint coverage, it
-# just moves the existing one earlier. `.chezmoitemplates/*` is deliberately excluded: those
-# are template partials assembled into other scripts, not standalone valid shell, and CI never
-# lints them directly either.
-#
-# Always exits 0: this is a heads-up, not a gate. It never sets a "block" decision, because a
-# hard block on a pre-existing violation in a file touched for an unrelated reason would wedge
-# an agent that can't get past it. CI remains the actual enforcement backstop.
+# Advisory only, always exits 0. It never sets a "block" decision: a hard block on a
+# pre-existing violation in a file touched for an unrelated reason would wedge an agent that
+# has no way past it. Each repo's own CI remains the enforcement gate.
 
-input=$(cat)
+# A missing tool must never turn this into a noisy or failing hook.
+command -v jq >/dev/null 2>&1 || exit 0
+command -v shellcheck >/dev/null 2>&1 || exit 0
 
-file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+file_path=$(jq -r '.tool_input.file_path // empty')
+[ -n "$file_path" ] && [ -f "$file_path" ] || exit 0
 
-if [ -z "$file_path" ] || [ ! -f "$file_path" ]; then
-  exit 0
-fi
-
-repo_root=$(git -C "$(dirname "$file_path")" rev-parse --show-toplevel 2>/dev/null || true)
-if [ -z "$repo_root" ]; then
-  exit 0
-fi
-
-rel_path=${file_path#"$repo_root"/}
-
-in_scope=0
-case "$rel_path" in
-  .chezmoiscripts/*.tmpl) in_scope=1 ;;
-  private_dot_local/bin/*) in_scope=1 ;;
-  private_dot_local/bash/*) in_scope=1 ;;
-  private_dot_config/mise/tasks/*) in_scope=1 ;;
-  dot_bashrc | dot_profile) in_scope=1 ;;
-  private_dot_claude/hooks/*.sh) in_scope=1 ;;
-esac
-
-if [ "$in_scope" -eq 0 ]; then
-  exit 0
-fi
-
-# Degrade gracefully: a broken/missing toolchain must never turn into a noisy or hanging hook.
-if ! command -v shellcheck >/dev/null 2>&1; then
-  exit 0
-fi
-
-report() {
-  # $1: message body. Printed for a human watching the transcript, and surfaced to Claude via
-  # additionalContext so it can act on it - without ever setting "decision":"block".
-  printf '%s\n' "$1" >&2
-  jq -n --arg ctx "$1" '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}'
+# Decide shell-ness from the file itself rather than from a path allowlist, so this keeps
+# working in repos whose layout nobody anticipated. Extension first (cheap, and the only
+# signal for sourced fragments that legitimately have no shebang), then the shebang - which
+# is what catches the extension-less executables that most real scripts turn out to be.
+# zsh is deliberately absent: shellcheck cannot analyse it and would only emit noise.
+is_shell_script() {
+  case "$1" in
+    *.sh | *.bash | *.ksh | *.dash) return 0 ;;
+    *.zsh) return 1 ;;
+  esac
+  head -n 1 "$1" 2>/dev/null | grep -qE '^#!.*[ /](sh|bash|dash|ksh)( |$)'
 }
 
-tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
+is_shell_script "$file_path" || exit 0
 
-target="$file_path"
-render_note=""
+# A .shellcheckrc is found by walking up from the script's own directory, so each repo's own
+# suppressions apply automatically with no path wiring needed here.
+sc_output=$(shellcheck "$file_path" 2>&1) && exit 0
 
-case "$file_path" in
-  *.tmpl)
-    if ! command -v chezmoi >/dev/null 2>&1; then
-      exit 0
-    fi
+printf '%s\n' "$sc_output" >&2
+jq -n --arg ctx "shellcheck found issues in ${file_path} (advisory, not blocking):
 
-    patched="$tmpdir/patched.tmpl"
-    cp "$file_path" "$patched"
-    # Same two patches lint.yaml applies before rendering (see .github/workflows/lint.yaml,
-    # "Shellcheck chezmoi scripts" step): force the darwin-only branches to evaluate against
-    # this machine's real (linux) .chezmoi.os, and replace bitwardenSecrets calls with a
-    # literal so rendering never shells out to fetch a real secret on every edit.
-    sed -i 's|"darwin"|"linux"|' "$patched"
-    sed -i 's|{{ (bitwardenSecrets ".*" .bwsAccessToken).value }}|fake-test-value|' "$patched"
-
-    rendered="$tmpdir/rendered"
-    if ! chezmoi execute-template --source="$repo_root" <"$patched" >"$rendered" 2>"$tmpdir/render.err"; then
-      err=$(tail -c 500 "$tmpdir/render.err")
-      report "shellcheck-on-edit: could not render ${rel_path} via 'chezmoi execute-template' (lint skipped). ${err}"
-      exit 0
-    fi
-    target="$rendered"
-    render_note=" (rendered from template)"
-    ;;
-esac
-
-if [ ! -s "$target" ]; then
-  # Empty render (e.g. a darwin-only script rendered on linux) - nothing to lint.
-  exit 0
-fi
-
-rcflag=()
-[ -f "$repo_root/.shellcheckrc" ] && rcflag=(--rcfile "$repo_root/.shellcheckrc")
-
-# Shellcheck picks a dialect from the filename extension when there's no shebang, which
-# matters for extension-less/no-shebang sourced files (private_dot_local/bash/*, dot_bashrc,
-# dot_profile); reuse the original file's basename against the rendered content so that still
-# works correctly.
-sc_target="$tmpdir/$(basename "${file_path%.tmpl}")"
-[ "$target" = "$sc_target" ] || cp "$target" "$sc_target"
-
-if sc_output=$(shellcheck "${rcflag[@]}" "$sc_target" 2>&1); then
-  exit 0
-fi
-
-sc_output=${sc_output//$sc_target/$rel_path}
-report "shellcheck found issues in ${rel_path}${render_note} (non-blocking, mirrors CI's shellcheck job):
-
-${sc_output}"
+${sc_output}" '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}'

--- a/private_dot_claude/hooks/executable_shellcheck-on-edit.sh
+++ b/private_dot_claude/hooks/executable_shellcheck-on-edit.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PostToolUse hook: run shellcheck against a shell script right after Claude edits it, so
+# feedback that would otherwise only arrive from CI on push shows up at edit time instead.
+#
+# Scope is intentionally the same set of paths lint.yaml's chezmoi/shellcheck jobs already
+# treat as shell scripts (see TESTING.md) - this hook doesn't invent new lint coverage, it
+# just moves the existing one earlier. `.chezmoitemplates/*` is deliberately excluded: those
+# are template partials assembled into other scripts, not standalone valid shell, and CI never
+# lints them directly either.
+#
+# Always exits 0: this is a heads-up, not a gate. It never sets a "block" decision, because a
+# hard block on a pre-existing violation in a file touched for an unrelated reason would wedge
+# an agent that can't get past it. CI remains the actual enforcement backstop.
+
+input=$(cat)
+
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$file_path" ] || [ ! -f "$file_path" ]; then
+  exit 0
+fi
+
+repo_root=$(git -C "$(dirname "$file_path")" rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "$repo_root" ]; then
+  exit 0
+fi
+
+rel_path=${file_path#"$repo_root"/}
+
+in_scope=0
+case "$rel_path" in
+  .chezmoiscripts/*.tmpl) in_scope=1 ;;
+  private_dot_local/bin/*) in_scope=1 ;;
+  private_dot_local/bash/*) in_scope=1 ;;
+  private_dot_config/mise/tasks/*) in_scope=1 ;;
+  dot_bashrc | dot_profile) in_scope=1 ;;
+  private_dot_claude/hooks/*.sh) in_scope=1 ;;
+esac
+
+if [ "$in_scope" -eq 0 ]; then
+  exit 0
+fi
+
+# Degrade gracefully: a broken/missing toolchain must never turn into a noisy or hanging hook.
+if ! command -v shellcheck >/dev/null 2>&1; then
+  exit 0
+fi
+
+report() {
+  # $1: message body. Printed for a human watching the transcript, and surfaced to Claude via
+  # additionalContext so it can act on it - without ever setting "decision":"block".
+  printf '%s\n' "$1" >&2
+  jq -n --arg ctx "$1" '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}'
+}
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+target="$file_path"
+render_note=""
+
+case "$file_path" in
+  *.tmpl)
+    if ! command -v chezmoi >/dev/null 2>&1; then
+      exit 0
+    fi
+
+    patched="$tmpdir/patched.tmpl"
+    cp "$file_path" "$patched"
+    # Same two patches lint.yaml applies before rendering (see .github/workflows/lint.yaml,
+    # "Shellcheck chezmoi scripts" step): force the darwin-only branches to evaluate against
+    # this machine's real (linux) .chezmoi.os, and replace bitwardenSecrets calls with a
+    # literal so rendering never shells out to fetch a real secret on every edit.
+    sed -i 's|"darwin"|"linux"|' "$patched"
+    sed -i 's|{{ (bitwardenSecrets ".*" .bwsAccessToken).value }}|fake-test-value|' "$patched"
+
+    rendered="$tmpdir/rendered"
+    if ! chezmoi execute-template --source="$repo_root" <"$patched" >"$rendered" 2>"$tmpdir/render.err"; then
+      err=$(tail -c 500 "$tmpdir/render.err")
+      report "shellcheck-on-edit: could not render ${rel_path} via 'chezmoi execute-template' (lint skipped). ${err}"
+      exit 0
+    fi
+    target="$rendered"
+    render_note=" (rendered from template)"
+    ;;
+esac
+
+if [ ! -s "$target" ]; then
+  # Empty render (e.g. a darwin-only script rendered on linux) - nothing to lint.
+  exit 0
+fi
+
+rcflag=()
+[ -f "$repo_root/.shellcheckrc" ] && rcflag=(--rcfile "$repo_root/.shellcheckrc")
+
+# Shellcheck picks a dialect from the filename extension when there's no shebang, which
+# matters for extension-less/no-shebang sourced files (private_dot_local/bash/*, dot_bashrc,
+# dot_profile); reuse the original file's basename against the rendered content so that still
+# works correctly.
+sc_target="$tmpdir/$(basename "${file_path%.tmpl}")"
+[ "$target" = "$sc_target" ] || cp "$target" "$sc_target"
+
+if sc_output=$(shellcheck "${rcflag[@]}" "$sc_target" 2>&1); then
+  exit 0
+fi
+
+sc_output=${sc_output//$sc_target/$rel_path}
+report "shellcheck found issues in ${rel_path}${render_note} (non-blocking, mirrors CI's shellcheck job):
+
+${sc_output}"

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -28,6 +28,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/shellcheck-on-edit.sh",
+            "timeout": 15
+          }
+        ]
+      }
     ]
   },
   "permissions": {


### PR DESCRIPTION
Closes #675.

Adds a `PostToolUse` hook that runs `shellcheck` on a shell script immediately after Claude edits it, so the feedback arrives at edit time instead of from CI after a push.

## Scope

The hook is installed at **user level** (`~/.claude/settings.json`), so it fires on every edit in every repository. It decides whether a file is a shell script **from the file itself** — extension (`.sh`, `.bash`, `.ksh`, `.dash`), falling back to the shebang (`#!.*[ /](sh|bash|dash|ksh)`) — rather than from a path allowlist. That keeps it working in repos whose layout nobody anticipated, and catches the extension-less executables that most real scripts turn out to be.

`.zsh` is deliberately excluded: shellcheck cannot analyse zsh and would only emit noise.

A `.shellcheckrc` is discovered by walking up from the script's own directory, so each repo's own suppressions apply with no path wiring in the hook.

## Advisory, never blocking

It never sets `"decision":"block"` and always exits 0. Findings go to Claude via `hookSpecificOutput.additionalContext` and to stderr for a human. A hard block on a pre-existing violation in a file touched for an unrelated reason would wedge an agent with no way past it; each repo's CI remains the enforcement gate.

Missing `jq`, missing `shellcheck`, a non-shell file, or a path that no longer exists all exit 0 silently — a broken toolchain must never turn into a noisy or failing hook.

## Verification

Exercised directly by feeding the hook real tool payloads:

| Case | Result |
|---|---|
| `homelab-ops-kubernetes-apps` script, clean | silent |
| same script, injected `SC2006` | fires |
| `homelab-ops-kubernetes-clusters` script, clean | silent |
| same script, injected `SC2006` | fires |
| extension-less file, bash shebang, injected `SC2006` | fires |
| Python file | silent |
| Markdown file | silent |
| `.zsh` file | silent |
| nonexistent path | silent |

The hook lints clean under `shellcheck` itself, and stays silent when run against its own source through its own code path. `pre-commit` passes.

## Note on the first revision

The initial version scoped itself to a hardcoded list of *this repo's* directory globs and carried chezmoi template-rendering logic. That was wrong: a globally-installed hook that no-ops across the ~55 shell scripts in the rest of the estate and activates only in the repo that stores it. The template rendering existed only because this repo happens to keep its scripts as chezmoi templates — a property of the delivery mechanism, not of the job — and it reported *rendered* line numbers against *source* paths (~40 lines of drift measured on two templates), so that feedback was misleading regardless. Dropped; CI still lints this repo's templates.

112 lines → 41.
