### PR TITLE
feat(claude): markdownlint Markdown files automatically on edit

### DIFF
--- a/private_dot_claude/hooks/executable_markdownlint-on-edit.sh
+++ b/private_dot_claude/hooks/executable_markdownlint-on-edit.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PostToolUse hook: run markdownlint-cli2 on a Markdown file right after Claude edits it, in
+# whatever repo Claude happens to be working in. Settings are user-level, so this fires
+# everywhere - the point is to shorten the markdownlint feedback loop generally, not to
+# mirror any one repo's CI.
+#
+# Advisory only, always exits 0. It never sets a "block" decision: a hard block on a
+# pre-existing violation in a file touched for an unrelated reason would wedge an agent that
+# has no way past it. Each repo's own CI remains the enforcement gate.
+
+# A missing tool must never turn this into a noisy or failing hook.
+command -v jq >/dev/null 2>&1 || exit 0
+command -v markdownlint-cli2 >/dev/null 2>&1 || exit 0
+
+file_path=$(jq -r '.tool_input.file_path // empty')
+[ -n "$file_path" ] && [ -f "$file_path" ] || exit 0
+
+case "$file_path" in
+  *.md | *.markdown) ;;
+  *) exit 0 ;;
+esac
+
+# markdownlint-cli2 resolves a repo's own .markdownlint-cli2.{yaml,jsonc,...} by walking up
+# from the target file, independent of this shell's cwd - confirmed empirically, not from the
+# --config help text. No --config is passed here: forcing one config on every repo would
+# defeat the point of each repo choosing (or not choosing) its own rule set.
+ml_output=$(markdownlint-cli2 "$file_path" 2>&1) && exit 0
+
+printf '%s\n' "$ml_output" >&2
+jq -n --arg ctx "markdownlint found issues in ${file_path} (advisory, not blocking):
+
+${ml_output}" '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}'

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -42,6 +42,11 @@
             "type": "command",
             "command": "$HOME/.claude/hooks/yamllint-on-edit.sh",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/markdownlint-on-edit.sh",
+            "timeout": 15
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Adds a `PostToolUse` hook (`private_dot_claude/hooks/executable_markdownlint-on-edit.sh`), installed at user level, that runs `markdownlint-cli2` against a Markdown file right after Claude edits it.
- Directly mirrors the shellcheck-on-edit hook (#718): Markdown-ness is decided from the file extension (`.md`/`.markdown`), never a path allowlist, so it works in every repo — not just this one.
- Advisory only: never blocks, always exits 0, reports via `hookSpecificOutput.additionalContext` and stderr.
- Degrades silently when `markdownlint-cli2` or `jq` is missing, the file isn't Markdown, or the path no longer exists.

## Config discovery — established empirically, not from `--help`

`markdownlint-cli2 --help` advertises `.markdownlint-cli2.jsonc`, but every repo here ships the `.yaml` variant, and it wasn't clear whether config discovery works when the tool is invoked with an absolute path from an unrelated cwd (exactly how a hook calls it). Tested directly:

- A file in a repo whose `.markdownlint-cli2.yaml` disables `MD013` produces **no** MD013 finding when invoked with `cwd=/tmp` and an absolute path — same result as running from the repo root. Confirms discovery walks up from the target file, not from cwd.
- The same style of file in a repo **without** a config produces the default-rules `MD013` finding, again from an unrelated cwd.
- Conclusion: no `--config` flag is needed or wanted. Passing one would force this repo's rule choices onto every repo instead of honoring each repo's own config (or defaults, where none exists) — which is also how the hook keeps its noise budget in check, since a repo that doesn't care about a rule has already turned it off.

## Test plan

- [x] Injected a real violation (trailing spaces + hard tabs) into a **foreign repo** (a scratch copy of `homelab-ops-kubernetes-apps`'s own `.markdownlint-cli2.yaml` + a new file — the real repo was never touched) and confirmed the hook fires, invoked from an unrelated cwd.
- [x] Confirmed silence (empty stdout/stderr, exit 0) on a clean Markdown file in that same foreign repo.
- [x] Confirmed a repo *without* a `.markdownlint-cli2.yaml` falls back to default rules (MD013 fires).
- [x] Confirmed `.markdown` extension is recognized in addition to `.md`.
- [x] Exercised degradation paths, each silent with exit 0: `markdownlint-cli2` missing from `PATH`, `jq` missing from `PATH`, non-Markdown file, and a path that no longer exists.
- [x] `shellcheck --rcfile .shellcheckrc`, `pre-commit run` on changed files — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)