### PR TITLE
feat(claude): yamllint YAML files automatically on edit

### DIFF
--- a/private_dot_claude/hooks/executable_yamllint-on-edit.sh
+++ b/private_dot_claude/hooks/executable_yamllint-on-edit.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PostToolUse hook: yamllint a YAML file right after Claude edits it, in whatever repo
+# Claude happens to be working in. Settings are user-level, so this fires everywhere - the
+# point is to shorten the yamllint feedback loop generally, not to mirror any one repo's CI.
+#
+# Advisory only, always exits 0. It never sets a "block" decision: a hard block on a
+# pre-existing violation in a file touched for an unrelated reason would wedge an agent that
+# has no way past it. Each repo's own CI remains the enforcement gate.
+
+# A missing tool must never turn this into a noisy or failing hook.
+command -v jq >/dev/null 2>&1 || exit 0
+command -v yamllint >/dev/null 2>&1 || exit 0
+
+file_path=$(jq -r '.tool_input.file_path // empty')
+[ -n "$file_path" ] && [ -f "$file_path" ] || exit 0
+
+# Extension only - no content sniffing needed. A `*.yaml.tmpl` file doesn't end in .yaml or
+# .yml, so chezmoi templates are already excluded here; rendering them is a property of how
+# some repos store their files, not of whether the file is YAML.
+case "$file_path" in
+  *.yaml | *.yml) ;;
+  *) exit 0 ;;
+esac
+
+# Unlike shellcheck, which finds .shellcheckrc by walking up from the target file's own
+# directory, yamllint only looks in its current working directory and upward - it never looks
+# relative to the file being linted. A hook running with some other cwd would silently miss
+# the repo's own .yamllint, so the repo root has to be found and passed explicitly.
+config_file=""
+if command -v git >/dev/null 2>&1; then
+  repo_root=$(git -C "$(dirname "$file_path")" rev-parse --show-toplevel 2>/dev/null) || repo_root=""
+  if [ -n "$repo_root" ] && [ -f "$repo_root/.yamllint" ]; then
+    config_file="$repo_root/.yamllint"
+  fi
+fi
+
+# --strict turns warnings (e.g. a missing "---" document-start) into a non-zero exit too, so
+# they reach the reporting branch below instead of being swallowed by `&& exit 0` on a
+# warnings-only file. This hook stays advisory either way - --strict only affects whether a
+# finding gets surfaced at all, not whether it can block anything.
+if [ -n "$config_file" ]; then
+  yl_output=$(yamllint --strict -c "$config_file" "$file_path" 2>&1) && exit 0
+else
+  yl_output=$(yamllint --strict "$file_path" 2>&1) && exit 0
+fi
+
+printf '%s\n' "$yl_output" >&2
+jq -n --arg ctx "yamllint found issues in ${file_path} (advisory, not blocking):
+
+${yl_output}" '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}'

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -37,6 +37,11 @@
             "type": "command",
             "command": "$HOME/.claude/hooks/shellcheck-on-edit.sh",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/yamllint-on-edit.sh",
+            "timeout": 15
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Adds a `PostToolUse` hook (`private_dot_claude/hooks/executable_yamllint-on-edit.sh`) that runs `yamllint` on a YAML file right after Claude edits it, mirroring the shellcheck-on-edit hook (#718) in shape and constraints.
- Decides YAML-ness from the file's own extension (`*.yaml`/`*.yml`), never a path allowlist, so it works uniformly across every repo it's installed into (this is a user-level hook, `~/.claude/settings.json`). A `*.yaml.tmpl` file doesn't match either extension, so chezmoi templates are skipped without any special-casing.
- Advisory only: always exits 0, never sets a block decision, and reports findings via `hookSpecificOutput.additionalContext` (plus stderr for a human).
- Degrades silently: missing `yamllint`, missing `jq`, a non-YAML file, or a path that no longer exists all exit 0 quietly.

## Config discovery — verified against yamllint 1.38.0 source, not assumed

`yamllint`'s `find_project_config_filepath()` (`cli.py`) walks upward from **its current working directory**, not from the file being linted — the opposite of `shellcheck`, which walks up from the target file's own directory to find `.shellcheckrc`. Confirmed empirically: invoking `yamllint <absolute-path>` from an unrelated cwd picks up neither the target repo's `.yamllint` nor any ancestor of the file — only the invoking process's cwd chain is consulted. Since a hook's cwd isn't guaranteed to be the repo root of the file being edited, the hook resolves the repo root itself (`git -C "$(dirname "$file_path")" rev-parse --show-toplevel`) and passes `-c <root>/.yamllint` explicitly when that file exists, falling back to yamllint's built-in defaults otherwise.

## `--strict` decision

The hook always runs with `--strict`. This isn't about mirroring CI's blocking gate (the hook stays advisory regardless) — it's a control-flow necessity: without `--strict`, a warnings-only file exits 0, which the hook's `yamllint ... && exit 0` short-circuit would treat as "nothing to report", silently dropping every warning. `--strict` promotes warnings to a non-zero exit so they reach the reporting branch.

## Testing

Ran the hook directly (`echo '{"tool_input":{"file_path":"..."}}' | hook.sh`) against a scratch git repo outside `dotfiles` (copied `.yamllint` from `homelab-ops-kubernetes-apps`, never modified that repo), invoked from an unrelated cwd (`/tmp`) each time:

- [x] Clean file with a repo-config rule tweak (`document-start: present: false`) → silent, exit 0
- [x] Injected violation (duplicate key) → caught, reported via stderr + `additionalContext`, still exit 0
- [x] Restored `document-start: present: true` → warning-only violation (missing `---`) surfaces (proves the `--strict` reasoning above)
- [x] Same repo with **no** `.yamllint` at all → falls back to yamllint defaults, still catches the violation
- [x] `yamllint` missing from `PATH` → silent, exit 0
- [x] `jq` missing from `PATH` → silent, exit 0
- [x] Non-YAML file (`.sh`) → silent, exit 0
- [x] Path that no longer exists → silent, exit 0
- [x] `.yaml.tmpl` file with the same duplicate-key violation → silent, exit 0 (never rendered, never linted)
- [x] Empty/missing `tool_input.file_path` → silent, exit 0

Also ran `shellcheck --rcfile .shellcheckrc` and `pre-commit run --all-files` locally against the changed files — clean.

## Test plan

- [ ] CI lint workflow passes (shellcheck job covers this script; JSON check covers `settings.json`)
- [ ] Reviewer spot-checks the hook fires in a real session on an edited YAML file

Closes #719