### PR TITLE
fix(dev-tools): stop brew bundle racing its own auto-cleanup (#754)

### DIFF
--- a/.chezmoiscripts/run_before_10_homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_before_10_homebrew.sh.tmpl
@@ -48,12 +48,35 @@ manage_homebrew_system_packages() {
   log_success "Homebrew | Homebrew system packages have been installed."
 }
 
+cleanup_homebrew_cache() {
+  # HOMEBREW_NO_INSTALL_CLEANUP (see .chezmoitemplates/homebrew.env) turns off the automatic
+  # cleanup that races Homebrew's own parallel downloads. Reclaim the cache deterministically
+  # here instead -- unconditionally, but only once `brew bundle` is done and nothing is
+  # downloading concurrently -- so disabling that cleanup doesn't let the cache grow forever.
+  #
+  # Housekeeping must never fail a bootstrap that otherwise succeeded, and must never *look*
+  # like one either: that misreading is the whole point of this ticket. So the output is
+  # buffered and only replayed when cleanup worked; a failure collapses to a single warning
+  # and the script carries on.
+  local cleanup_log="${TMPDIR:-/tmp}/homebrew-cleanup.$$.log"
+  log_info "Homebrew | Cleaning up old versions and stale downloads..."
+  if brew cleanup > "${cleanup_log}" 2>&1; then
+    sed -E -n 's|^|    |p' "${cleanup_log}"
+    log_success "Homebrew | Homebrew cleanup completed."
+  else
+    log_warning "Homebrew | Homebrew cleanup failed; cache not reclaimed this run, continuing."
+  fi
+  rm -f "${cleanup_log}"
+}
+
 main() {
   show_homebrew_env
   echo
   manage_homebrew_package_manager
   echo
   manage_homebrew_system_packages "{{ .chezmoi.sourceDir }}/Brewfile.system.{{ .chezmoi.os }}"
+  echo
+  cleanup_homebrew_cache
   echo "-------------------------------------------------------------------------------------------"
   echo
 }

--- a/.chezmoitemplates/homebrew.env
+++ b/.chezmoitemplates/homebrew.env
@@ -12,6 +12,11 @@ HOMEBREW_CELLAR=${HOMEBREW_PREFIX}/Cellar
 HOMEBREW_NO_ANALYTICS=1
 HOMEBREW_NO_AUTO_UPDATE=1
 HOMEBREW_NO_ENV_HINTS=1
+# Homebrew's post-install auto-cleanup walks the download cache while its own parallel bottle
+# downloads are still writing *.incomplete temp files, so an entry can vanish between stat and
+# unlink and abort the whole chezmoi apply. Cleanup is done deterministically instead, after
+# `brew bundle` finishes, in .chezmoiscripts/run_before_10_homebrew.sh.tmpl.
+HOMEBREW_NO_INSTALL_CLEANUP=1
 {{ if eq .chezmoi.os "linux" }}
 HOMEBREW_NO_SANDBOX_LINUX=1
 {{ end }}


### PR DESCRIPTION
Fixes #754.

## What changed

Two files:

- `.chezmoitemplates/homebrew.env` — sets `HOMEBREW_NO_INSTALL_CLEANUP=1`, so every script that
  sources it (all 10 `.chezmoiscripts/*`, plus `private_dot_env` for the interactive shell) stops
  taking part in the race.
- `.chezmoiscripts/run_before_10_homebrew.sh.tmpl` — adds `cleanup_homebrew_cache()`, an explicit
  `brew cleanup` run **after** `brew bundle` has fully completed, when nothing is downloading
  concurrently.

## The judgement call: deterministic cleanup, not no cleanup

The ticket asked whether the explicit `brew cleanup` belongs here or is over-reach. **It belongs
here**, for two reasons:

1. `homebrew.env` is also templated into `private_dot_env`, so `HOMEBREW_NO_INSTALL_CLEANUP=1` is
   not scoped to bootstrap — it disables auto-cleanup for every interactive `brew install` on the
   machine, forever. Shipping only the env var would trade an intermittent failure for a slow,
   silent, machine-wide disk leak, and the person who eventually notices has no obvious thread back
   to this change. Fixing that later would be a second change to the same two files.
2. `brew cleanup` with no arguments is `Cleanup#clean!` — literally the same routine Homebrew's own
   periodic full cleanup invokes (`Cleanup.periodic_clean!` → `Cleanup.new.clean!`, see
   `Library/Homebrew/cleanup.rb` in Homebrew 6.0.15). So this is not a new class of destructive
   behaviour, only the same behaviour on a deterministic schedule at a safe point, instead of
   opportunistically in the middle of parallel downloads. `run_before_10` runs on every apply, so
   it fires more often than Homebrew's 30-day periodic clean, not less.

`HOMEBREW_DOWNLOAD_CONCURRENCY=1` was **not** set. The ticket rightly calls it a fallback: it would
serialise downloads and slow every bootstrap, and the evidence below shows the race path is gone
without it.

### The explicit cleanup cannot become a new failure mode

The whole point of #754 is that a *cache* problem aborted a bootstrap and read as "the dotfiles
broke". Adding a cleanup step must not recreate that, so it is deliberately defanged:

- it runs under `if brew cleanup > "${cleanup_log}" 2>&1; then` — `errexit` does not apply inside an
  `if` condition, and the function's last statement is `rm -f`, so a failure can never propagate;
- Homebrew's output is buffered to a temp file and replayed (indented) **only on success**;
- a failure collapses to exactly one `log_warning` line — no `[ERROR]`, no Homebrew stack trace.

## Verification

### 1. `HOMEBREW_NO_INSTALL_CLEANUP` reaches every consumer

Rendered the way CI does (`.chezmoi.os` forced to `linux`, `bitwardenSecrets` blanked, then
`chezmoi execute-template --source=.`): `HOMEBREW_NO_INSTALL_CLEANUP=1` is present in **all 10**
rendered `.chezmoiscripts/*` scripts that source `homebrew.env` (exactly the 10 that template it —
the two that don't are the macOS `defaults`/launch-agent scripts, which never touch Homebrew) and
in rendered `private_dot_env`.

In a real run it is not just rendered but *live*: `show_homebrew_env` in the sandbox pod logs prints
`HOMEBREW_NO_INSTALL_CLEANUP=1` from the actual process environment.

### 2. Fresh `ubuntu:24.04` bootstraps — 6 on this branch, 10 on `main`

Each pod: bare `ubuntu:24.04`, `git clone` the branch unauthenticated over https, install chezmoi,
render `run_before_10_homebrew.sh.tmpl` and run it — exactly what chezmoi executes. Baseline is 10
pods across two batches (4 + 6); every pod was deleted afterwards.

A genuinely bare image also needs `build-essential` (`oven-sh/bun/bun` aborts with "No developer
tools installed" without it) plus `fontconfig`, `jq` and `zip` — installed as pod setup, deliberately
**not** "fixed" in the repo, per the ticket's Context note.

| arm | fresh pods | passed | pods hitting `dir_s_rmdir` |
|---|---|---|---|
| this branch | 6 | 6 | 0 |
| `main` (baseline) | 10 | 10 | 0 |

**Stated plainly: the flake did not reproduce on `main` in this sandbox** (0 of 10), so
these runs are *not* a measured before/after. The 2-in-4 rate in the ticket was seen elsewhere; a
single-node 4-CPU Talos sandbox evidently doesn't hit the same timing. Repeated green runs on this
branch therefore only show the change doesn't regress anything — on their own they would not be
evidence that the race is fixed.

### 3. So the race is closed by mechanism, not by statistics

Because the statistical arm is inconclusive, each pod also runs a deterministic probe of the exact
code path that raises `dir_s_rmdir`. `Cleanup.install_formula_clean!` unconditionally prints
``Running `brew cleanup <formula>`…`` when it fires, and `Cleanup.periodic_clean_due?` touches a
`.cleaned` marker in `HOMEBREW_CACHE`; both are gated on `HOMEBREW_NO_INSTALL_CLEANUP`. The probe
sources the *rendered* env block from the script under test, deletes the marker, and runs
`brew reinstall starship`:

| arm | probe result | `.cleaned` marker |
|---|---|---|
| this branch | `PROBE=AUTOCLEANUP_DISABLED` (6/6) | absent (6/6) |
| `main` | `PROBE=AUTOCLEANUP_RAN` (6/6) | present (6/6) |

That is the actual claim: the racing routine no longer executes during install at all. A race in
code that never runs cannot fire.

### 4. Cache growth is bounded

Every run on this branch shows the deterministic cleanup executing and succeeding after
`brew bundle`:

```
[INFO] Homebrew | Cleaning up old versions and stale downloads...
    Pruned 0 symbolic links and 21 directories from /home/linuxbrew/.linuxbrew
[SUCCESS] Homebrew | Homebrew cleanup completed.
```

(A first-ever bootstrap has no superseded versions to reclaim yet — the volume shows up on later
`chezmoi update` runs, which is precisely when the cache would otherwise grow.)

### 5. The failure branch was exercised, not assumed

Simulated by stubbing `brew` in front of the *rendered* script and driving `cleanup_homebrew_cache`
under `set -euo pipefail`:

| `brew cleanup` exits | script exit | reached end | `[ERROR]` lines | `[WARNING]` lines | Homebrew noise | temp log left |
|---|---|---|---|---|---|---|
| 1 (fails) | 0 | yes | 0 | 1 | 0 | 0 |
| 0 (succeeds) | 0 | yes | 0 | 0 | replayed, indented | 0 |

### 6. Idempotency

`full-apply-test` on this PR is **green** — that job is `chezmoi init --apply` followed by
`chezmoi apply --force`, i.e. exactly the "apply twice is clean" criterion, on a real bootstrap.

Independently, 2 more fresh `ubuntu:24.04` pods ran the rendered script **twice** back to back
(a bare image, unlike a GitHub runner). Both passes exited 0 in both pods; the second pass finds
`brew bundle` a no-op and `brew cleanup` with nothing left to reclaim, and prints no output — it
does not re-fail, re-download, or churn the cache (297M after pass 1, 297M after pass 2).

### 7. Linters

Run locally against the rendered output, as `TESTING.md` describes:

- `shellcheck --rcfile .shellcheckrc` on all rendered `.chezmoiscripts/*` — clean
- `shellcheck` on every executable in the repo (the broader CI sweep) — clean
- `dotenv-linter --skip QuoteCharacter` on rendered `private_dot_env` / `private_dot_env.secrets` —
  no problems found (sanity-checked against a deliberately broken file so "clean" isn't a no-op;
  note `UnorderedKey` would have fired had the new key been inserted out of alphabetical order)
- `yamllint --strict`, `markdownlint-cli2`, `pre-commit run --all-files` — all clean

CI on this PR agrees: `chezmoi`, `pre-commit`, `detect-changed-files` and `full-apply-test` all
pass (the other lint jobs correctly skip — no yaml/markdown/workflow files changed).

## Not proven here

- **A real workstation apply.** `chezmoi apply --force` was not run on the actual machine, because
  `brew cleanup` there would delete real cached bottles as a side effect of a test. Covered by
  `full-apply-test` and the double-run pods instead (§6).
- **macOS.** Same as everything else in this repo: CI is Linux-only. The change is OS-independent
  (no `darwin`/`linux` branch), but it has not been executed on macOS.
- **That the original flake is gone in the environment where it was seen.** It never reproduced in
  this sandbox, so that can't be measured from here — see §2/§3.
