### PR TITLE
fix(cli-tools): restrict btop to linux, it has no macOS build

### DIFF
--- a/private_dot_config/mise/config.toml
+++ b/private_dot_config/mise/config.toml
@@ -22,7 +22,10 @@ uv             = "0.12.3"
 # aqua backend resolves the exact same artifact/checksum regardless of prefix, since it reconstructs the
 # real upstream tag from the aqua registry's own per-package version template.
 "aqua:ajeetdsouza/zoxide"        = "0.10.0"
-"aqua:aristocratos/btop"         = "1.4.7"
+# Linux-only: aqua-registry's btop package declares `supported_envs: [linux]` and publishes no darwin
+# asset, so mise cannot install it on macOS -- without this filter `mise install` aborts the whole apply
+# with "unsupported env: darwin/arm64". mise.lock carries linux-* platforms only, so nothing to relock.
+"aqua:aristocratos/btop"         = { version = "1.4.7", os = ["linux"] }
 "aqua:atuinsh/atuin"             = "18.18.1"
 "aqua:bitwarden/clients"         = "2026.7.0"
 "aqua:bitwarden/sdk-sm"          = "2.1.0"


### PR DESCRIPTION
Fixes a macOS bootstrap abort found running `chezmoi update` on the Mac.

## Symptom

```
mise ERROR Failed to install tools: aqua:aristocratos/btop@1.4.7
aqua:aristocratos/btop@1.4.7: unsupported env: darwin/arm64 (supported: ["linux"])
chezmoi: .chezmoiscripts/20_mise-install.sh: exit status 1
```

## Cause

aqua-registry's `pkgs/aristocratos/btop/registry.yaml` declares `supported_envs: [linux]` and publishes no darwin asset — btop simply cannot install on macOS. `private_dot_config/mise/config.toml` declared it unconditionally for every platform.

**Latent until #753.** The old seed script installed a subset and `run_after` ran `mise upgrade --yes`, which only touches already-installed tools — so btop was silently never installed on macOS and never complained. #753 replaced that with a single `mise install` over the full config, which attempts every entry and hard-fails on an unsupported one. The bad config predates that change; #753 turned a silent skip into a fatal abort. Linux-only CI structurally could not catch it.

## Fix

```toml
"aqua:aristocratos/btop" = { version = "1.4.7", os = ["linux"] }
```

## Verification

**`os` works on `aqua:` backend entries** — it's a `[tools]`-level filter applied before the backend runs. Verified on mise 2026.8.3 against this exact entry, with an unfiltered control to rule out unrelated exclusion:

| `aqua:aristocratos/btop` on Linux | listed from that config |
|---|---|
| `os = ["linux"]` | yes |
| `os = ["macos"]` | no |
| no filter (control) | yes |

Schema-backed too: `os_filter_item` in `mise.jdx.dev/schema/mise.json` documents `linux`, `macos`, `windows`, `macos/arm64`, `linux/x64` as examples. Note its pattern is permissive, so a typo would silently filter rather than fail validation — the behavioural check above is the real one.

**No relock needed** — `mise.lock` carries only `linux-*` platforms for btop, consistent with the registry.

**Swept all 49 locked tools** for entries lacking any `macos-*` platform. btop is the only one, so this is the complete fix rather than the first of several.

## Not covered

Not executed on macOS — no macOS CI leg exists. The change is a declarative filter with no darwin code path, and the failing behaviour is fully explained by the registry, but the passing run on the Mac is the real confirmation.