### PR TITLE
feat(claude): block commit identity and signing overrides in a PreToolUse hook

### DIFF
--- a/private_dot_claude/hooks/executable_guard-git-identity.sh
+++ b/private_dot_claude/hooks/executable_guard-git-identity.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PreToolUse hook: every commit must be attributed to, and signed with, whatever the user's
+# own git config already resolves to. Two families of override get refused:
+#
+#   1. Identity supplied with the commit - `--author`, `-c user.email=...`,
+#      GIT_AUTHOR_* / GIT_COMMITTER_* in the environment, `git config` writes to `user.*`.
+#   2. Signing weakened or skipped - `--no-gpg-sign`, `-c commit.gpgsign=false`, a
+#      substituted `gpg.program` or signing key, GIT_CONFIG_* injection.
+#
+# The configured values are never read here: the hook has no opinion on what the identity or
+# signing key should be, only that nothing at the command line gets to replace it. That also
+# keeps it correct on a machine whose config it has never seen.
+#
+# Blocking, not advisory - unlike the *-on-edit.sh hooks, there is no pre-existing-violation
+# problem to wedge an agent on. Every deny corresponds to a flag the caller just typed, and
+# dropping that flag is always a valid way forward. A clean command exits silently rather
+# than emitting "allow", so ordinary permission prompts still apply to it.
+
+# A missing tool must never turn this into a noisy or failing hook.
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+[ -n "$cmd" ] || exit 0
+
+deny() {
+  jq -cn --arg r "Blocked by guard-git-identity.sh: $1. Commits must use the identity and signing configuration already in the user's git config - drop the override and re-run." \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
+  exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Unambiguous overrides: matched against the whole command, no parsing needed.
+#
+# None of these strings has a legitimate read-only use, so context is irrelevant - a match
+# anywhere is an override attempt regardless of which git subcommand it lands on, and that
+# holds even when quoting or nesting defeats the tokenizer below. Matched case-insensitively
+# because git config keys are case-insensitive.
+# ---------------------------------------------------------------------------
+
+# Identity and signing config injected through the environment, including the GIT_CONFIG_*
+# family - which can set any key at all, and is the most direct way around every other check.
+if printf '%s' "$cmd" | grep -qE 'GIT_(AUTHOR|COMMITTER)_(NAME|EMAIL)='; then
+  deny "author/committer identity is being set via GIT_AUTHOR_*/GIT_COMMITTER_* environment variables"
+fi
+if printf '%s' "$cmd" | grep -qE 'GIT_CONFIG_(COUNT|KEY_[0-9]+|VALUE_[0-9]+|GLOBAL|SYSTEM|NOSYSTEM)='; then
+  deny "GIT_CONFIG_* environment variables are being used to override git config for this command"
+fi
+
+# The same keys passed inline to git itself: `-c key=value`, `-ckey=value`, or
+# `--config-env=key=ENVVAR`.
+if printf '%s' "$cmd" | grep -qiE '(^|[[:space:]])(-c[[:space:]]*|--config-env=)(user\.(name|email|signingkey)|commit\.gpgsign|tag\.gpgsign|gpg\.)'; then
+  deny "identity or signing config is being overridden inline with git -c/--config-env"
+fi
+
+# Signing turned off outright. Valid only on commands that create a commit, so no subcommand
+# check is needed to rule out a read-only use.
+if printf '%s' "$cmd" | grep -qE '(^|[[:space:]])--no-gpg-sign([[:space:]]|$)'; then
+  deny "--no-gpg-sign disables commit signing"
+fi
+
+# Editing a git config file directly, rather than through git. Redirections only - reading
+# these paths stays fine.
+if printf '%s' "$cmd" | grep -qE '>>?[[:space:]]*[^[:space:]]*(\.git/config|\.gitconfig|git/config)'; then
+  deny "a git config file is being written to directly"
+fi
+
+# ---------------------------------------------------------------------------
+# Context-dependent overrides: these need to know which git subcommand they belong to.
+#
+# `--author` and `-S` are the awkward ones - `git log --author=x` and `git log -Sneedle` are
+# perfectly ordinary searches, and only the commit-creating subcommands turn them into an
+# override. So the command gets split into segments, and each git invocation in it is parsed
+# far enough to name its subcommand.
+# ---------------------------------------------------------------------------
+
+lc() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# Subcommands that write a commit and therefore accept --author / -S<keyid>. `git tag` is
+# absent on purpose: it signs tags, not commits, and its own gpgsign key is covered above.
+creates_commit() {
+  case "$1" in
+    commit | commit-tree | cherry-pick | revert | rebase | merge | am | citool) return 0 ;;
+  esac
+  return 1
+}
+
+# Split on shell separators so each segment holds at most one command. Mapping every one of
+# ;&| to a newline handles && and || too, at the cost of empty segments - which are skipped.
+# Newlines in the command need no translation: the read loop below already splits on them.
+segments=$(printf '%s' "$cmd" | tr ';&|' '\n')
+
+while IFS= read -r seg; do
+  [ -n "$seg" ] || continue
+
+  read -ra toks <<<"$seg" || true
+  n=${#toks[@]}
+
+  # Find the git invocation, stepping over any leading VAR=value assignments. An absolute or
+  # relative path to git counts, a word merely containing "git" does not.
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    case "${toks[$i]}" in
+      git | */git) break ;;
+    esac
+    i=$((i + 1))
+  done
+  [ "$i" -lt "$n" ] || continue
+  i=$((i + 1))
+
+  # Walk git's own options to reach the subcommand. The ones listed take a separate value,
+  # which must be skipped so it can't be mistaken for the subcommand.
+  sub=""
+  while [ "$i" -lt "$n" ]; do
+    case "${toks[$i]}" in
+      -c | -C | --git-dir | --work-tree | --namespace | --exec-path | --config-env)
+        i=$((i + 2))
+        ;;
+      -*)
+        i=$((i + 1))
+        ;;
+      *)
+        sub=$(lc "${toks[$i]}")
+        i=$((i + 1))
+        break
+        ;;
+    esac
+  done
+  [ -n "$sub" ] || continue
+
+  if creates_commit "$sub"; then
+    while [ "$i" -lt "$n" ]; do
+      case "${toks[$i]}" in
+        --author | --author=*)
+          deny "git $sub is being given an explicit --author"
+          ;;
+        # An attached value is a specific key to sign with; a bare -S/--gpg-sign just signs
+        # with the configured one and is left alone.
+        -S?* | --gpg-sign=*)
+          deny "git $sub is being pointed at a specific signing key instead of the configured one"
+          ;;
+      esac
+      i=$((i + 1))
+    done
+  elif [ "$sub" = "config" ]; then
+    # `git config` reaching any of the guarded keys is an override unless it is only reading
+    # them. Covers the modern `git config set|unset ...` spellings as well, since the check
+    # is on the key rather than on the verb.
+    key_hit=0
+    read_only=0
+    for ((j = i; j < n; j++)); do
+      case "$(lc "${toks[$j]}")" in
+        --get | --get-all | --get-regexp | --get-urlmatch | --list | -l) read_only=1 ;;
+        user.name* | user.email* | user.signingkey* | commit.gpgsign* | tag.gpgsign* | gpg.*) key_hit=1 ;;
+      esac
+    done
+    if [ "$key_hit" -eq 1 ] && [ "$read_only" -eq 0 ]; then
+      deny "git config is being used to change the identity or signing settings"
+    fi
+  fi
+done <<<"$segments"
+
+exit 0

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -46,6 +46,11 @@
             "type": "command",
             "command": "$HOME/.claude/hooks/guard-git-push.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/guard-git-identity.sh",
+            "timeout": 10
           }
         ]
       },


### PR DESCRIPTION
Adds `private_dot_claude/hooks/executable_guard-git-identity.sh` and registers it on the existing `Bash` PreToolUse matcher, next to `guard-git-push.sh`.

## What it blocks

**Identity supplied with the commit** — the commit must use whatever `git config` already resolves to:

- `git commit --author="X <x@y>"` (and on `cherry-pick`/`revert`/`rebase`/`merge`/`am`/`commit-tree`/`citool`)
- `git -c user.name=… / user.email=… / user.signingkey=…`, `-cuser.email=…`, `--config-env=user.email=VAR`
- `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` / `GIT_COMMITTER_NAME` / `GIT_COMMITTER_EMAIL` in the environment
- `git config [--global|--local|set|--unset] user.*`

**Signing weakened or skipped:**

- `--no-gpg-sign`
- `-c commit.gpgsign=false`, `-c tag.gpgsign=…`, `-c gpg.program=…` (substituted signer)
- `-S<keyid>` / `--gpg-sign=<keyid>` — pointing at a key other than the configured one
- `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` / `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` / `GIT_CONFIG_NOSYSTEM` injection
- `git config … commit.gpgsign / tag.gpgsign / gpg.*`
- direct redirection into a git config file (`>> ~/.gitconfig`, `>> .git/config`)

## Design notes

- The hook never reads the configured identity or key — it only refuses the mechanisms that would replace them, so it needs no knowledge of the machine it runs on.
- Unambiguous strings (`--no-gpg-sign`, `-c user.email=`, `GIT_*`) are matched against the whole command, which holds even where quoting defeats tokenization.
- `--author` and `-S` are ambiguous — `git log --author=x` and `git log -Sneedle` are ordinary searches — so those are matched only after parsing the segment far enough to identify a commit-creating subcommand.
- Blocking rather than advisory (unlike the `*-on-edit.sh` hooks): every deny corresponds to a flag the caller just typed, and dropping it is always a valid way forward. A clean command exits silently instead of emitting `allow`, so normal permission prompts still apply.
- Bare `-S` / `--gpg-sign` and `--reset-author` stay allowed — both defer to the configured identity/key.

## Testing

`shellcheck --rcfile .shellcheckrc` and `pre-commit run --files …` pass. A 43-case allow/deny matrix was run against the hook (26 deny cases, 17 allow cases including `git log --author=`, `git log -Sneedle`, `git config --get user.email`, `git commit -S`, `git commit --reset-author`) — all as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)