### PR TITLE
fix(dev-tools): replace bash-completion v1 with bash-completion@2

### DIFF
--- a/.chezmoiscripts/run_after_60_shell_completions.sh.tmpl
+++ b/.chezmoiscripts/run_after_60_shell_completions.sh.tmpl
@@ -40,7 +40,12 @@ main() {
   helm completion bash > ~/.local/bash-completions/helm
   kubectl completion bash > ~/.local/bash-completions/kubectl
   kustomize completion bash > ~/.local/bash-completions/kustomize
-  mise completion bash --include-bash-completion-lib > ~/.local/bash-completions/mise
+  # Deliberately without --include-bash-completion-lib: that flag prepends a full ~3.5k-line copy of
+  # the bash-completion 2.x library to the generated file, for hosts that have no bash-completion at
+  # all. Here bash-completion@2 is a system package (Brewfile.system.*), so the copy is redundant --
+  # and harmful: sourcing it re-runs the framework's whole init, re-reading every file in the compat
+  # dir, and pins the loaded library to whatever version mise happens to vendor.
+  mise completion bash > ~/.local/bash-completions/mise
   zoxide init bash > ~/.local/bash-completions/zoxide
   log_success "Shell Completions | Configured."
   echo "-------------------------------------------------------------------------------------------"

--- a/.chezmoiscripts/run_before_10_homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_before_10_homebrew.sh.tmpl
@@ -36,6 +36,27 @@ manage_homebrew_trusted_taps() {
   done
 }
 
+retire_superseded_bash_completion() {
+  # `bash-completion` (v1.3, bash-3.2 era) is superseded by `bash-completion@2`, and homebrew marks
+  # the two as conflicting -- so `brew bundle` cannot install the replacement while v1 is still
+  # installed. Retire it here, idempotently, ahead of the bundle run.
+  #
+  # v1 is not merely stale. It drops ~190 legacy completion scripts into etc/bash_completion.d that
+  # call its `have` helper, and v1 unsets that helper once it has finished loading. bash-completion
+  # 2.x reads that same directory as its compat dir, so anything pulling in a 2.x library after v1
+  # has loaded re-sources all ~190 scripts with `have` already gone -- one "command not found: have"
+  # per script, on every new interactive shell. Removing v1 removes those scripts with it.
+  if ! command -v brew > /dev/null; then
+    log_error "Homebrew | Brew binary is not in path, cannot proceed!"
+    exit 1
+  fi
+  if brew list --formula --versions bash-completion &> /dev/null; then
+    log_info "Homebrew | Retiring superseded formula: bash-completion (v1)..."
+    brew uninstall bash-completion 2>&1 | sed -E -n 's|^|    |p'
+    log_success "Homebrew | bash-completion (v1) retired, bash-completion@2 installs below."
+  fi
+}
+
 manage_homebrew_system_packages() {
   local brew_file="$1"
   if ! command -v brew > /dev/null; then
@@ -74,6 +95,7 @@ main() {
   echo
   manage_homebrew_package_manager
   echo
+  retire_superseded_bash_completion
   manage_homebrew_system_packages "{{ .chezmoi.sourceDir }}/Brewfile.system.{{ .chezmoi.os }}"
   echo
   cleanup_homebrew_cache

--- a/Brewfile.system.darwin
+++ b/Brewfile.system.darwin
@@ -1,6 +1,6 @@
 # Baseline System Packages
 brew "bash"
-brew "bash-completion"
+brew "bash-completion@2"  # v1 is bash-3.2 era and conflicts with this; run_before_10 retires it
 brew "ca-certificates"
 brew "coreutils"
 brew "curl"

--- a/Brewfile.system.linux
+++ b/Brewfile.system.linux
@@ -1,4 +1,5 @@
 # Baseline System Packages
+brew "bash-completion@2"  # completion framework the generated completions in run_after_60 rely on
 brew "gnupg"
 brew "nmap"
 brew "starship"

--- a/private_dot_local/bash/shell-completions.bash
+++ b/private_dot_local/bash/shell-completions.bash
@@ -1,11 +1,15 @@
 # Load shell completions
 
 # enable bash completions
+#
+# The homebrew entry is `etc/profile.d/bash_completion.sh`, not `etc/bash_completion`: that is the
+# path `bash-completion@2` documents and the only one it ships. The old v1 formula happened to
+# provide both, so this covers either -- but nothing here may load v1, see Brewfile.system.darwin.
+# The remaining branches are the distro-packaged locations, for hosts where homebrew isn't the
+# provider.
 if ! shopt -oq posix; then
-  if [ -f $HOMEBREW_PREFIX/etc/bash_completion ]; then
-    . $HOMEBREW_PREFIX/etc/bash_completion
-  elif [ -f /usr/local/etc/bash_completion ]; then
-    . /usr/local/etc/bash_completion
+  if [ -f $HOMEBREW_PREFIX/etc/profile.d/bash_completion.sh ]; then
+    . $HOMEBREW_PREFIX/etc/profile.d/bash_completion.sh
   elif [ -f /usr/share/bash-completion/bash_completion ]; then
     . /usr/share/bash-completion/bash_completion
   elif [ -f /etc/bash_completion ]; then


### PR DESCRIPTION
## The symptom

Every new interactive shell (new iTerm tab) opens with a burst of:

```
bash: command not found: have
bash: command not found: have
... (~29x)
```

## Root cause

Three things compounding:

1. Homebrew's `bash-completion` formula is still **v1.3** — released 2011, targets bash 3.2, while `Brewfile.system.darwin` also installs bash 5.3. It drops ~190 legacy completion scripts into `$HOMEBREW_PREFIX/etc/bash_completion.d/`, each opening with `have <cmd> &&`.
2. v1 runs `unset -f have` at the very end of its own load (`etc/bash_completion:1678`), so the helper is gone the moment `shell-completions.bash` finishes sourcing it.
3. `run_after_60` generated the mise completion with `--include-bash-completion-lib`, which prepends a full vendored copy of the bash-completion **2.x** library (3478 lines) ahead of the 33-line `_mise` function. Sourcing `~/.local/bash-completions/mise` therefore re-ran the entire 2.x framework init — which reads `etc/bash_completion.d` as its *compat dir* and re-sourced all ~190 v1 scripts, now with `have` undefined.

`mise activate bash` installs a `command_not_found_handle`, which is what renders each failure as `bash: command not found: have` rather than bash's default wording.

Traced with `PS4='+[${BASH_SOURCE}:${LINENO}]: ' bash -ixc true`:

```
+++[~/.local/bash-completions/mise:3466]: . /opt/homebrew/etc/bash_completion.d/abook
++++[/opt/homebrew/etc/bash_completion.d/abook:3]: have abook
++++[~/.bashrc:263]: /opt/homebrew/bin/mise hook-not-found -s bash -- have
++++[~/.bashrc:269]: echo 'bash: command not found: have'
```

## The fix

Move to the formula that matches the installed bash, and stop vendoring a second copy of the framework.

| File | Change |
|---|---|
| `Brewfile.system.darwin` | `bash-completion` → `bash-completion@2` |
| `Brewfile.system.linux` | add `bash-completion@2` — dropping the vendored library needs a provider here too |
| `run_before_10_homebrew.sh.tmpl` | uninstall the conflicting v1 formula before `brew bundle` |
| `run_after_60_shell_completions.sh.tmpl` | drop `--include-bash-completion-lib` |
| `private_dot_local/bash/shell-completions.bash` | source `etc/profile.d/bash_completion.sh` |

Two notes on the less obvious pieces:

- **Why `run_before_10` needs a migration step.** Homebrew declares `bash-completion` and `bash-completion@2` mutually conflicting, and `brew bundle` here runs without `--cleanup`, so it can neither remove v1 nor install the replacement over it — bundle would just fail. The new `retire_superseded_bash_completion` is idempotent (guarded on `brew list --formula --versions bash-completion`) and no-ops on Linux and on already-migrated hosts. Uninstalling is also what clears the ~190 legacy scripts.
- **Why the path in `shell-completions.bash` changes.** `bash-completion@2` ships `etc/profile.d/bash_completion.sh` and does *not* create `etc/bash_completion`, so the existing first branch would silently miss and fall through. The `/usr/local/etc/bash_completion` branch is dropped as redundant — `$HOMEBREW_PREFIX` already resolves to `/usr/local` on Intel macs. Homebrew patches v2's compat dir to `$HOMEBREW_PREFIX/etc/bash_completion.d`, so completions shipped by other formulae (mise, uv, chezmoi, docker, git, starship…) keep loading.

## Verification

- Rendered both templates the way CI does (`.chezmoi.os` forced to `linux`, `bitwardenSecrets` blanked) and shellchecked the output with this repo's `.shellcheckrc` — clean. `shell-completions.bash` shellchecks clean directly.
- Replayed shell startup against a compat dir pruned to only the non-v1 formulae, with the mise completion regenerated *without* the flag: **no `have` errors**, `_comp_compgen`, `_mise` and `__start_kubectl` all bind, and `complete -p mise` is registered.
- Functionally exercised the un-vendored mise completion against the system library — `mise ins<TAB>` → `install install-into`, confirming `_mise` resolves `_comp_compgen`/`_comp_ltrim_colon_completions` from bash-completion@2 rather than needing its own copy.

Not yet run on this machine: `chezmoi apply` will do the brew swap on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)