### PR TITLE
ci(github-actions): add zizmor lint gate to lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -170,3 +170,11 @@ jobs:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).yaml_all_changed_files }}
       mise_ignore_cfg: private_dot_config/mise/config.toml
+
+  zizmor:
+    needs: [detect-changes]
+    if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).actions_any_changed == 'true' }}
+    uses: ppat/github-workflows/.github/workflows/lint-zizmor.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    with:
+      git_ref: ${{ github.head_ref || github.ref }}
+      mise_ignore_cfg: private_dot_config/mise/config.toml


### PR DESCRIPTION
## Summary

- Adds a `zizmor` job to `.github/workflows/lint.yaml`, calling the shared
  `ppat/github-workflows/.github/workflows/lint-zizmor.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0`
  reusable workflow, gated the same way as the other `actions`-scoped lint jobs in this
  file (`needs: [detect-changes]`, runs when `actions_any_changed`).
- Passes `mise_ignore_cfg: private_dot_config/mise/config.toml`, matching every other
  reusable-workflow call already in this file. Without it the zizmor job's `mise`
  setup would pick up this repo's chezmoi-templated `mise/config.toml` (which contains
  unrendered Go-template syntax) instead of ignoring it, which is why every sibling job
  in `lint.yaml` already passes this input.

## Why

`homelab-ops-terraform` already runs zizmor (GitHub Actions static-analysis/security
linter) via this same reusable workflow. This brings `dotfiles` up to the same gate so
workflow supply-chain/permissions issues (unpinned actions, excessive permissions,
credential persistence, template injection, etc.) get caught uniformly across repos
instead of ad hoc per repo.

## zizmor findings

Ran `zizmor --format=plain --min-severity=medium --min-confidence=high --persona=regular .`
locally (the exact invocation `lint-zizmor.yaml` uses) against the repo with this change
applied. Result: **no findings** — clean gate, no fixes or suppressions needed.

For completeness, running zizmor with no severity/confidence filter surfaces two
pre-existing, out-of-scope items that don't meet the gate's `--min-confidence=high` bar
(so they don't fail CI) and were left untouched:

| Finding | Location | Confidence | Decision | Rationale |
|---|---|---|---|---|
| `artipacked` (checkout without `persist-credentials: false`) | `full-apply-test.yaml:44` (`actions/checkout`) | Low | Left as-is | Below the gate's high-confidence threshold; out of scope for a gate-introduction PR, and this checkout's `persist-credentials` behavior is unrelated to the zizmor-gate change. |
| `excessive-permissions` (no `permissions:` block) | `renovate.yaml:18` (`renovate` job) | Medium | Left as-is | Below the gate's high-confidence threshold; token/permission plumbing for the self-hosted Renovate job is out of scope here and shouldn't be changed without separately verifying it doesn't break the Renovate run. |

Also confirmed: `actions/checkout` has exactly one direct use in this repo
(`full-apply-test.yaml:44`), already pinned at `@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`
(current, untouched), and `actions/cache` is not used anywhere in this repo (nothing to add).

## Local verification

- `zizmor --format=plain --min-severity=medium --min-confidence=high --persona=regular .` — clean, no findings.
- `pre-commit run --all-files` — all hooks pass.
- `actionlint` — no new findings from this change (two pre-existing shellcheck warnings
  in the untouched `chezmoi` job, unrelated to this diff).

## Test plan

- [x] CI (`lint.yaml`) runs on this PR and the new `zizmor` job passes.