### PR TITLE
feat(claude): add reporting-order guidance to global CLAUDE.md

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -91,3 +91,6 @@ need permission.
   a conclusion already given, not build up to one.
 - Cut findings that can't change a decision; keep one anyway only if it's
   labeled incidental.
+- When I ask for a specific output format (table, list, diff, JSON, a
+  brevity level), keep using it for later updates on the same thread of
+  work, not just the reply that asked for it — until I say otherwise.

--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -72,3 +72,22 @@ need permission.
   task at hand (albeit within its scope, context, and constraints).
   Problem resolution outweighs correcting trivialities.
   (Alias: "substantive disagreement")
+
+## Reporting findings
+
+- Lead with the verdict: the first sentence answers the question asked or
+  states the bottom line, not the setup, the mechanism, or how it was found.
+  (Alias: "verdict first.")
+- Classify significance explicitly — active problem, latent condition whose
+  trigger isn't currently met, or background/FYI — rather than leaving
+  severity to be inferred from tone or length.
+- If it isn't a problem, say so in the same breath you raise it, and say why
+  it's worth mentioning at all.
+- State downstream implications next (what changes, what it constrains or
+  unblocks, who/what else it touches), then a recommendation. "Do nothing" is
+  a legitimate recommendation — state it as one, including what happens if
+  nothing is done.
+- Mechanism, evidence, and detail come last, or only on request: they support
+  a conclusion already given, not build up to one.
+- Cut findings that can't change a decision; keep one anyway only if it's
+  labeled incidental.


### PR DESCRIPTION
## Summary

Adds a "Reporting findings" section to `private_dot_claude/CLAUDE.md` (renders to `~/.claude/CLAUDE.md`).

**The defect this fixes**: findings were being reported in the order they were discovered rather than the order the reader needs them — mechanism and detail up front, with the verdict (does this matter, does it need action) arriving last or only after being asked for directly. The information was accurate but the ordering made it read as more significant or more urgent than it was, and cost the reader's attention establishing that.

**The rule**: lead with the verdict, classify significance explicitly (active problem / latent-and-not-currently-triggered / background), say plainly when something isn't a problem and why it's being mentioned at all, then downstream implications, then a recommendation (including "do nothing" as a legitimate one), with mechanism/evidence last or on request. Also covers a related, second failure mode: a requested output format (table, list, diff, brevity level) being honored for one reply and then dropped on the next update on the same topic — the rule makes a requested format persist for that thread of work until told otherwise. Both are written generically — they apply to research results, incident write-ups, code review, subagent summaries, or answering a direct question, not any one domain.

## Placement

Added as a new `##` section after "How to work", since none of the existing sections (Interpreting requests / When to ask vs. proceed / How to work) cover output structure — this fills a gap rather than competing with or overriding anything already there.

## Test plan

- [x] `markdownlint-cli2 --config .markdownlint-cli2.yaml private_dot_claude/CLAUDE.md` — 0 issues
- [x] `pre-commit run --files private_dot_claude/CLAUDE.md` — all hooks pass
- [x] CI (`lint.yaml`): `markdown/markdownlint`, `detect-changes`, `pre-commit` pass; `chezmoi`, `shellcheck`, `yaml`, `zizmor`, `github-actions`, `renovate-config-check` skipped (path filters — markdown-only change)