### PR TITLE
fix(ci): discover shellcheck full-sweep files at runtime instead of ALL

### DIFF
--- a/.github/scripts/discover-shellcheck-files.sh
+++ b/.github/scripts/discover-shellcheck-files.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Discover the repo's shell scripts for the "shellcheck" full-sweep job in lint.yaml.
+#
+# Why this exists: the reusable ppat/github-workflows lint-shellcheck.yaml's own ALL-discovery
+# selects files via `find ... -executable`. This repo is a chezmoi *source* tree: scripts are
+# committed at git mode 100644 and only gain the executable bit at deploy time, applied by
+# chezmoi via the `executable_` filename-prefix convention -- so -executable matches nothing
+# here, and the shared workflow's ALL path is a dead end for this repo specifically. That's a
+# storage convention this one consumer uses, not something the ~16-repo-shared workflow should
+# have to know about, so the fix lives here instead.
+#
+# Discover shell files the way a human would recognize them, from how each file declares
+# itself, not from its git mode:
+#   - a shebang naming sh/bash/dash/ksh
+#   - a `# shellcheck shell=...` directive -- how sourced files with no shebang (dot_bashrc,
+#     dot_profile, private_dot_local/bash/*.bash) self-declare their dialect
+#   - a .sh or .bash extension
+#
+# Chezmoi templates (*.tmpl) are excluded: they carry Go template syntax (`{{ }}`) that a
+# shell linter cannot parse. They're rendered and linted separately by the "chezmoi" job
+# elsewhere in lint.yaml.
+set -euo pipefail
+
+files=()
+while IFS= read -r -d '' file; do
+  file="${file#./}"
+
+  case "${file}" in
+    *.sh | *.bash)
+      files+=("${file}")
+      continue
+      ;;
+  esac
+
+  read -r first_line < "${file}" || true
+  if [[ "${first_line}" =~ ^#!.*[\ /](sh|bash|dash|ksh)([[:space:]]|$) ]]; then
+    files+=("${file}")
+    continue
+  fi
+
+  if grep -qE '^# shellcheck shell=(sh|bash|dash|ksh)([[:space:]]|$)' "${file}"; then
+    files+=("${file}")
+  fi
+done < <(find . -type f -not -path './.git/*' -not -name '*.tmpl' -print0)
+
+if [[ "${#files[@]}" -eq 0 ]]; then
+  echo "::error::no shell files discovered -- the discovery predicate in" \
+    "${BASH_SOURCE[0]} is likely broken (expected the repo's real shell inventory," \
+    "e.g. dot_bashrc, private_dot_local/bin/executable_*)" >&2
+  exit 1
+fi
+
+printf '%s\n' "${files[@]}" | sort

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -153,13 +153,50 @@ jobs:
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).renovate_all_changed_files }}
       mise_ignore_cfg: private_dot_config/mise/config.toml
 
-  shellcheck:
+  # The reusable lint-shellcheck.yaml's own ALL-discovery (used on the weekly scheduled sweep
+  # and workflow_dispatch) selects files via `find ... -executable`. This is a chezmoi source
+  # repo: scripts are committed at mode 100644 and only gain the executable bit at deploy time,
+  # applied by chezmoi via the `executable_` filename-prefix convention -- so ALL-discovery
+  # matches nothing here (verified with `git ls-tree`: every script is 100644). Compute the
+  # real file list ourselves instead of hardcoding one: see
+  # .github/scripts/discover-shellcheck-files.sh for the predicate and its rationale. Keeping
+  # this chezmoi-specific knowledge here, rather than teaching it to the shared workflow, is
+  # deliberate -- lint-shellcheck.yaml is consumed by ~16 repos.
+  # Always runs (rather than only on non-PR events) so the "shellcheck" job below -- which
+  # does have a conditional `if:` -- never has to reason about a skipped dependency.
+  shellcheck-discover-files:
     needs: [detect-changes]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      files: ${{ steps.discover.outputs.files }}
+    steps:
+    - name: Checkout current
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ github.head_ref || github.ref }}
+
+    - name: Discover shell scripts
+      id: discover
+      shell: bash
+      # yamllint disable-line rule:indentation
+      run: |
+        files="$(.github/scripts/discover-shellcheck-files.sh)"
+        {
+          echo "files<<EOF"
+          echo "${files}"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+        echo "discovered $(wc -l <<< "${files}") shell file(s):"
+        echo "${files}"
+
+  shellcheck:
+    needs: [detect-changes, shellcheck-discover-files]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).shellscripts_any_changed == 'true' }}
     uses: ppat/github-workflows/.github/workflows/lint-shellcheck.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
     with:
       git_ref: ${{ github.head_ref || github.ref }}
-      files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).shellscripts_all_changed_files }}
+      files: ${{ github.event_name != 'pull_request' && needs.shellcheck-discover-files.outputs.files || fromJSON(needs.detect-changes.outputs.results).shellscripts_all_changed_files }}
       mise_ignore_cfg: private_dot_config/mise/config.toml
 
   yaml:


### PR DESCRIPTION
## Why the sweep was empty

`lint.yaml`'s `shellcheck` job calls the org's reusable `lint-shellcheck.yaml` and passes
`files: ALL` on non-PR runs (the weekly scheduled sweep and `workflow_dispatch`). That
workflow's `ALL` path discovers scripts via `find ... -executable` (plus a shebang/extension
filter, added in a since-merged but not-yet-tagged upstream change). This repo is a chezmoi
*source* repo: scripts are committed at mode `100644` and only gain the executable bit at
deploy time via chezmoi's `executable_` filename-prefix convention. `git ls-tree` confirms
every script here is `100644`. So `-executable` has always matched **zero files**, and the
weekly full sweep — the safety net for anything a PR's changed-files filter missed — has been
silently checking nothing.

Per the constraint that `lint-shellcheck.yaml` is consumed by ~16 repos, this fix stays local
to `dotfiles`' own `lint.yaml` rather than teaching the shared workflow about one consumer's
storage convention.

## Approach: discover the file list at runtime, not a hardcoded list

An earlier version of this PR hardcoded the 18 file paths directly into the workflow YAML.
That was wrong, and rightly rejected: a static list silently stops covering a script the
moment one is added or renamed — exactly the same silent-under-coverage failure mode this fix
exists to eliminate, just moved one level up.

This version adds a `shellcheck-discover-files` job that runs
[`.github/scripts/discover-shellcheck-files.sh`](.github/scripts/discover-shellcheck-files.sh)
at CI time and feeds its output to the reusable workflow's `files` input on the non-PR path.
The predicate recognizes a file as shell from how it declares itself, never from git mode:

- a shebang naming `sh`/`bash`/`dash`/`ksh`
- a `# shellcheck shell=...` directive — how sourced files with no shebang (`dot_bashrc`,
  `dot_profile`, `private_dot_local/bash/*.bash`) self-declare their dialect
- a `.sh` or `.bash` extension

`*.tmpl` files are excluded: they carry Go template syntax (`{{ }}`) that shellcheck can't
parse — including them would recreate the exact SC1071-class problem a previous change in this
repo already fixed. They don't need to be added here anyway: the `chezmoi` job earlier in the
same `lint.yaml` workflow already renders and shellchecks them on its own `ALL` path (a `find`
that isn't gated on `-executable`).

There's also a guard: if discovery ever returns zero files, the job fails loudly
(`::error::no shell files discovered -- the discovery predicate is likely broken`) instead of
silently passing over nothing, so this specific bug class can't regress undetected.

## Verification against a hand-derived oracle

Before writing the predicate, I hand-enumerated the repo's real shell inventory — `git
ls-files`, checked every file's shebang/extension, cross-referenced `git ls-tree` for mode,
grepped for `{{ ` to separate real shell from chezmoi templates — arriving at 18 files. I then
ran the discovery script and diffed its output against that hand list: **exact match**. Running
it again after adding the discovery script itself correctly returned 19 (the 18 plus the new
script) — the predicate picks up its own file, which is the intended behavior, not a
discrepancy: it's real shell, added by this PR, so it should be linted too.

Ran `shellcheck --rcfile .shellcheckrc` at `v0.11.0` (this repo's pinned `SHELLCHECK_VERSION`)
over all 19 discovered files locally before pushing, and again via `pre-commit`. **All 19 pass
cleanly** — no genuine findings surfaced, nothing deferred.

## Design notes

- `shellcheck-discover-files` always runs (not gated to non-PR events) so the downstream
  `shellcheck` job's own conditional `if:` never has to reason about whether a `needs`
  dependency was skipped — a small always-on cost (~10s) traded for not depending on GitHub
  Actions' skip-propagation semantics for correctness.
- `dotfiles` still pins the reusable workflow at `v4.4.0`, which predates its per-file
  `PASS`/`FAIL` summary output (upstream added that after this repo's pin, and it isn't
  reflected in any tagged release yet as of this PR). So CI here won't show a `"N file(s)
  checked"` line — confirmation instead comes from the `shellcheck-discover-files` job's own
  log (`discovered N shell file(s): ...`) and the raw invocation line in the `shellcheck` job's
  log. Bumping the pin is a separate, out-of-scope decision.

## Out of scope, flagged for awareness

`private_dot_claude/hooks/executable_*.sh` (5 files) aren't matched by the `shellscripts`
category in this workflow's `detect-changes` `files_yaml`, so they go unchecked on PRs that
touch only those files day-to-day (the full sweep now covers them; PR-time doesn't). Separate,
pre-existing gap in the `detect-changes` glob — left for a follow-up.