### PR TITLE
chore(github-actions): update ppat/github-workflows (v4.4.0 -> v5.0.1)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   detect-changes:
-    uses: ppat/github-workflows/.github/workflows/detect-changed-files.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/detect-changed-files.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       # yamllint disable-line rule:indentation
       files_yaml: |
@@ -92,7 +92,7 @@ jobs:
           sed -i 's|"darwin"|"linux"|' "$sc"
           # don't want to fetch secrets during linting
           sed -i 's|{{ (bitwardenSecrets ".*" .bwsAccessToken).value }}|fake-test-value|' "$sc"
-          chezmoi execute-template --source=$(pwd) < "$sc" > "${sc%.tmpl}"
+          chezmoi execute-template --source="$(pwd)" < "$sc" > "${sc%.tmpl}"
           echo "running shellcheck..."
           shellcheck --rcfile .shellcheckrc "${sc%.tmpl}"
           echo "::endgroup::"
@@ -114,7 +114,7 @@ jobs:
           echo "rendering file..."
           # don't want to fetch secrets during linting
           sed -i 's|{{ (bitwardenSecrets ".*" .bwsAccessToken).value }}|fake-test-value|' "$e"
-          chezmoi execute-template --source=$(pwd) < "$e" > "${e%.tmpl}"
+          chezmoi execute-template --source="$(pwd)" < "$e" > "${e%.tmpl}"
           echo "running dotenv-linter..."
           dotenv-linter --skip QuoteCharacter "${e%.tmpl}"
           echo "::endgroup::"
@@ -123,7 +123,7 @@ jobs:
   github-actions:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).actions_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-github-actions.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-github-actions.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).actions_all_changed_files }}
@@ -132,14 +132,14 @@ jobs:
   markdown:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).markdown_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-markdown.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-markdown.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).markdown_all_changed_files }}
       mise_ignore_cfg: private_dot_config/mise/config.toml
 
   pre-commit:
-    uses: ppat/github-workflows/.github/workflows/lint-pre-commit.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-pre-commit.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       mise_ignore_cfg: private_dot_config/mise/config.toml
@@ -147,7 +147,7 @@ jobs:
   renovate-config-check:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).renovate_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-renovate-config-check.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-renovate-config-check.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).renovate_all_changed_files }}
@@ -193,7 +193,7 @@ jobs:
   shellcheck:
     needs: [detect-changes, shellcheck-discover-files]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).shellscripts_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-shellcheck.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-shellcheck.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && needs.shellcheck-discover-files.outputs.files || fromJSON(needs.detect-changes.outputs.results).shellscripts_all_changed_files }}
@@ -202,7 +202,7 @@ jobs:
   yaml:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).yaml_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).yaml_all_changed_files }}
@@ -211,7 +211,7 @@ jobs:
   zizmor:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).actions_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-zizmor.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-zizmor.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       mise_ignore_cfg: private_dot_config/mise/config.toml

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   renovate:
-    uses: ppat/github-workflows/.github/workflows/renovate.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/renovate.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       dry_run: ${{ github.event_name == 'pull_request' }}
       git_ref: ${{ github.head_ref || github.ref }}


### PR DESCRIPTION
## Summary

Bump every `ppat/github-workflows` ref used by this repo from `v4.4.0`
(`1e8ca1b00b6e69bdf5aef8b33111c594c051ff65`) to **v5.0.1**
(`667d20d10c8756b11feeab1ee691825ccea8f991`) — verified locally that this SHA
is exactly what `v5.0.1` resolves to (`git rev-list -n1 v5.0.1`). Full-SHA +
`# v5.0.1` trailing-comment pin convention preserved throughout; `grep -rn
"1e8ca1b00b6e69bdf5aef8b33111c594c051ff65\|v4.4.0" .github/` now returns
nothing.

Per the maintainer's standing instruction for this batch, this PR is scoped
to the version bump and whatever it minimally breaks — it does **not** touch
`renovate-presets`, does not introduce commitlint config (this repo has
none, and none was added), and does not do unrelated cleanup.

**Supersedes #780** (`chore(github-actions): update ppat/github-workflows
(v4.4.0 -> v5.0.0)`) — that PR is left open/untouched; this one targets
v5.0.1 instead of v5.0.0.

## Refs bumped (8 occurrences, both call sites)

`.github/workflows/lint.yaml`:
- `detect-changed-files.yaml`
- `lint-github-actions.yaml`
- `lint-markdown.yaml`
- `lint-pre-commit.yaml`
- `lint-renovate-config-check.yaml`
- `lint-shellcheck.yaml`
- `lint-yaml.yaml`
- `lint-zizmor.yaml`

`.github/workflows/renovate.yaml`:
- `renovate.yaml`

The repo-specific `mise_ignore_cfg: private_dot_config/mise/config.toml`
input is preserved on every call site that had it. `lint.yaml`'s local,
non-reusable `chezmoi` job (which calls
`ppat/homelab-ops-actions/actions/setup-repository-tools` directly — a
different dependency) was left alone except for the shellcheck fix below.
`full-apply-test.yaml` has no `ppat/github-workflows` refs at all, so nothing
to bump there.

Diffed every called workflow's `workflow_call.inputs` between v4.4.0 and
v5.0.1 (`git diff 1e8ca1b0...667d20d1 -- .github/workflows/<file>` in
`ppat/github-workflows`, one file at a time): no input renames or removals
on any workflow this repo calls. `lint-zizmor.yaml` gained four new optional
inputs (`advisory_only`, `min_confidence`, `min_severity`, `persona`), all
defaulting to current behaviour — not added to this repo's call site since
current behaviour is what we want. Everything else was internal
implementation/env-var changes only.

## What v5 breaks here, and the fix

`lint-github-actions.yaml` bumps `actionlint` v1.7.4 -> v1.7.12, which turns
on its `-shellcheck` integration. Confirmed locally that this integration
was genuinely inert at v1.7.4 (same repo, same `-shellcheck "shellcheck
--rcfile .shellcheckrc"` invocation, actionlint 1.7.4 → exit 0, zero
findings) and is live at v1.7.12. It also appends `--norc`, so
`.shellcheckrc`'s broad disable list (SC1090/1091/2046/2059/2068/2086/2153/
2155/2236/2034) never reaches it — this is the repo's `shellcheck` findings
its own dedicated `shellcheck` job has never surfaced.

Reproduced the gate locally: installed actionlint v1.7.12 and shellcheck
v0.11.0 (the version v5 pins for the shellcheck integration) via mise, then
ran exactly what `lint-github-actions.yaml`'s v5 `run:` block runs:

```
actionlint -shellcheck shellcheck
```

(and, to mirror the PR-path invocation with an explicit changed-file list:
`actionlint -shellcheck shellcheck .github/workflows/lint.yaml
.github/workflows/renovate.yaml` — same two findings, confirming file-arg
scoping doesn't change the result here.)

### Finding list (2 total, both SC2046)

| # | Location | Finding | Decision |
|---|----------|---------|----------|
| 1 | `lint.yaml:95` (local `chezmoi` job, "Shellcheck chezmoi scripts" step) | `SC2046: Quote this to prevent word splitting` on `chezmoi execute-template --source=$(pwd) < "$sc" > "${sc%.tmpl}"` | **Fixed** — quoted to `--source="$(pwd)"` |
| 2 | `lint.yaml:117` (local `chezmoi` job, "Lint chezmoi dotenv files" step) | Same pattern, `--source=$(pwd) < "$e" > "${e%.tmpl}"` | **Fixed** — quoted to `--source="$(pwd)"` |

Both live in this repo's own local `chezmoi` job (not a reusable-workflow
call), so nothing about the v5 bump's input surface is involved in the fix
itself — only the newly-live linter surfaced it.

**Why "fix" and not "suppress" here**, per the "don't change what argv a
command receives" rule: quoting `$(pwd)` changes argv only when the command
substitution's output contains IFS whitespace or a glob character. Proved
this with a stub script that echoes `argv[n]=<...>` per positional
argument:

- Realistic case (CI's actual `working-directory: ./current`, an absolute
  path with no spaces): quoted and unquoted produce **byte-identical**
  single-token argv (`argv[2]=<--source=/path/to/cwd>` either way).
- Pathological case (cwd containing a space, constructed only to
  demonstrate the failure mode `SC2046` warns about): unquoted splits into
  *three* argv tokens (`--source=/path/to/has`, `space`); quoted stays a
  single correct token.

So in the environment this workflow actually runs in, the fix is behaviour-
preserving by construction, and only diverges from "no change" in exactly
the case the finding exists to catch. No `# shellcheck disable=` needed, no
`.shellcheckrc` edit, no repo-wide disable.

Every other workflow file in the repo (`renovate.yaml`, `full-apply-test.yaml`)
produced zero findings.

### Other v5 changes reviewed, no repo impact

- `lint-renovate-config-check.yaml` bumps `renovate-config-validator`
  `44.14.12` -> `44.30.4` and quotes `${rc}` in its own `for` loop — internal
  to the reusable workflow, no call-site change needed.
- `lint-shellcheck.yaml`'s file-selection change (shebang/extension-based
  instead of executable-bit-based, one invocation per file with
  `PASS`/`FAIL` lines and an `N file(s) checked, M failed` summary) doesn't
  change what *this* repo passes it, because of #779 (see below).
- `lint-markdown.yaml` / `lint-yaml.yaml` gained the same `$VAR` ->
  `"$VAR"`-style quoting internally; no call-site impact.

## #779 interaction (explicit file list, not the `ALL` path)

#779 added `.github/scripts/discover-shellcheck-files.sh` and the
`shellcheck-discover-files` job specifically because this repo is a chezmoi
*source* tree (scripts committed at mode `100644`, only gaining the
executable bit at `chezmoi apply` time) — so `lint-shellcheck.yaml`'s own
`ALL`-discovery (`find ... -executable`) matches nothing here. This repo
therefore always passes `lint-shellcheck.yaml` an **explicit** `files:`
list computed by that script, never `ALL`.

v5's per-file selector only changes behaviour on the `ALL` path (shebang/
extension filtering replaces the executable-bit `find`). The explicit-list
path is unchanged in *what* gets checked — v5's diff literally routes the
caller-supplied list straight into `shellcheck_files` unfiltered (see the
`# Deliberate word splitting: the caller delimits its list with whitespace`
comment in v5's `lint-shellcheck.yaml`). What *does* change, because #779
noted this repo was pinned below the version that added it: v5's per-file
`PASS`/`FAIL` output and the `N file(s) checked, M failed` summary line now
appear in this repo's `shellcheck` job log for the first time — previously
it ran the whole list through one `shellcheck` invocation with no per-file
accounting.

Ran `.github/scripts/discover-shellcheck-files.sh` locally against this
branch: **19 files discovered**, unchanged from #779's baseline (bump
touched no shell files, only `.yaml` workflow files, which the discovery
predicate excludes).

## Verification

- `actionlint` (v1.7.12, plain — no shellcheck) over the whole repo: 0
  findings.
- `actionlint -shellcheck shellcheck` (v1.7.12 + shellcheck v0.11.0) over
  the whole repo, and again scoped to just the two changed files: 0
  findings after the quoting fix (2 before).
- `yamllint -c .yamllint --strict` on both changed files: passes.
- `pre-commit run --all-files` (via the commit hook): all applicable hooks
  passed.
- Local `.shellcheckrc`-based `shellcheck --rcfile .shellcheckrc` was not
  changed and was not the point — the whole issue is that `--norc` bypasses
  it for the `-shellcheck` integration.

CI on this PR is path-gated (`shellcheck`, `chezmoi`, etc. only run when
their paths change). Watching the actual PR run now; where a relevant job
is gated out here, will separately dispatch `lint.yaml` on this branch via
`workflow_dispatch` (which runs the full, non-path-gated sweep) and report
which run verified what.
