### PR TITLE
fix(vscode): lower tsserver heap ceiling, pin more UI-only extensions

### DIFF
--- a/private_Library/private_Application Support/private_Code/User/settings.json.tmpl
+++ b/private_Library/private_Application Support/private_Code/User/settings.json.tmpl
@@ -91,26 +91,67 @@
   "search.followSymlinks": false,
   // Cap the TypeScript server's heap instead of leaving it unbounded (default 3072 MiB).
   // `js/ts.tsserver.maxMemory` replaces the deprecated `typescript.tsserver.maxTsServerMemory`
-  // (still honored as a fallback in the installed extension, verified against its compiled
-  // dist/extension.js, but this stops relying on that and the Settings UI deprecation nag).
-  // Both are `scope: "window"` in the extension's own configuration.json -- not MACHINE or
-  // MACHINE_OVERRIDABLE -- so, like everything else in this section, this file is the only
-  // place it can live; the remote Machine settings file would silently drop it.
+  // (still honored as a fallback -- `readMaxTsServerMemory()` in the installed extension's
+  // compiled dist/extension.js reads `tsserver.maxMemory` with the old key as
+  // `fallbackSubSectionNameOverride` -- but this stops relying on that and on the Settings UI
+  // deprecation nag). That same function clamps whatever it reads with `Math.max(n, 128)`, so
+  // 128 MiB is the floor no value here can go below.
   //
-  // Value derivation: the operator wants the whole remote VS Code tree (extension host +
-  // every helper) under 2048 MiB. TypeScript spawns *two* processes that each read this same
-  // setting independently -- a full semantic server and a lighter "partialSemantic" one -- so
-  // this is a per-process ceiling, not a combined one; a pathological workspace can drive both
-  // toward it at once. 768 sits well above both processes' measured resting PSS on a live
-  // workspace (~142 MiB / ~112 MiB), leaving real headroom for a genuinely large project, while
-  // no longer leaving tsserver free to claim most of the 2048 MiB envelope by itself the way the
-  // previous 2048 setting effectively could (2 x 2048 = 4096, already over budget alone). Cost:
-  // on a large enough TypeScript project this trades an unbounded tsserver for a V8 heap OOM
-  // that the extension host catches and restarts tsserver from -- a visible but recoverable
-  // failure, not silent data loss. It is not a guarantee the whole tree fits 2048 MiB: most of
-  // that tree (extension host, file watcher, pty host, the JSON/Markdown/TOML language servers)
-  // exposes no heap-ceiling setting at all -- see remote.extensionKind below for the lever that
-  // actually shrinks the extension host, and dotfiles#772 for the rest of that story.
+  // Scope, and why this file: both keys are `scope: "window"` in the extension's own
+  // package.json (verified against the copy installed under the remote server's
+  // extensions/typescript-language-features). The remote Machine settings file parses only
+  // [MACHINE, MACHINE_OVERRIDABLE] and silently drops everything else, so this file -- the
+  // client-side User settings -- is the only place it can live. The consequence is worth
+  // stating because it constrains the value: this applies to *every* VS Code window, local
+  // macOS projects included, not just the remote workspace.
+  //
+  // Value. There is exactly one process class in the remote tree with a heap knob, and this is
+  // it; the extension host, file watcher, pty host and the JSON/Markdown/TOML language servers
+  // have none at any value (see remote.extensionKind below, which is the only lever that
+  // shrinks the extension host). TypeScript spawns *two* processes that each read this setting
+  // independently -- a full semantic server and a lighter "partialSemantic" one -- so it is a
+  // per-process ceiling, not a combined one.
+  //
+  // 768 is deliberately NOT low enough to fire before the workspace template's memory watchdog,
+  // and that ordering is a decision rather than an oversight. The watchdog gives tsserver a
+  // 320 MiB share of a 2048 MiB envelope, compared in PSS. A heap ceiling bounds V8's old space
+  // only, while PSS also carries the node binary, native allocations, external ArrayBuffers and
+  // V8's new/code/large-object spaces -- a remainder that is near-constant per role rather than
+  // proportional to the heap. So the two relate by addition, not by a ratio:
+  //
+  //     peak PSS  ~=  resting PSS + ceiling
+  //
+  // and for V8 to fail first the ceiling would have to be <= share - resting, which on measured
+  // resting PSS of 141/111 MiB is about 179 MiB. Three reasons not to set it there:
+  //   1. It is within spitting distance of the 128 MiB clamp above -- no room left to be wrong.
+  //   2. Window scope (above) means it would cap tsserver on real TypeScript projects opened
+  //      locally on the Mac, where 179 MiB is a crash rather than a bound. A ceiling set too
+  //      low turns a working feature into a crash loop; a ceiling set too high is merely inert.
+  //      That asymmetry decides it.
+  //   3. It would not buy the recoverable failure it appears to. A V8 fatal heap error and an
+  //      external SIGKILL arrive at the same handler in the extension, which shows "The JS/TS
+  //      language service crashed." and, after five crashes in five minutes, "The service will
+  //      not be restarted." The watchdog's ten-minute dwell cannot reach that rate. A binding
+  //      heap ceiling on a project that legitimately needs the memory reaches it immediately.
+  //
+  // So the watchdog stays first for tsserver, and this ceiling keeps its original and only job:
+  // stop a runaway tsserver from claiming the whole pod. 768 sits well above both processes'
+  // measured resting PSS while bounding the pair at ~1.5 GiB of heap instead of the 6 GiB two
+  // 3072-defaults sanction. Cost on a large TypeScript project: a project whose server needs
+  // more than 768 MiB of heap will crash and restart. That is a real cost and it is why this is
+  // not lower.
+  //
+  // Nothing here is load-bearing for the template: the watchdog is coherent with these settings
+  // absent, which is the state it is actually in most of the time (see below).
+  //
+  // Not yet verified in force. Live evidence from a remote session started after dotfiles#773
+  // set the old key: both tsserver processes still run with --max-old-space-size=3072, VS Code's
+  // default. Since the extension does honor the old key as a fallback, that means these settings
+  // are not reaching the window at all -- most likely simply not applied on the Mac. To check:
+  // in a reconnected remote window open Settings, search "tsserver.maxMemory", and confirm both
+  // the value AND its provenance ("Modified elsewhere"/User). Then, in a terminal on the remote,
+  // `pgrep -af tsserver.js` must show --max-old-space-size=768. If the Settings UI shows 768 but
+  // the process shows 3072, the window has not reloaded since the change.
   "js/ts.tsserver.maxMemory": 768,
   "typescript.disableAutomaticTypeAcquisition": true,
   // Reduce the git extension's background repository scanning.
@@ -141,9 +182,22 @@
   //
   // Pins extensions that do no workspace-filesystem or child-process work to the client (UI)
   // extension host instead of the remote one, so their code never runs on the remote at all --
-  // the extension host is the tree's biggest, most volatile process (685-738 MiB PSS observed,
-  // climbing over time) precisely because of what it loads, so this is the "load less" lever
-  // rather than a heap ceiling. Each entry below was checked against the extension actually
+  // the extension host is the tree's biggest, most volatile process (528 -> 843 MiB PSS over
+  // three days on one live workspace, the hourly minimum climbing throughout) precisely because
+  // of what it loads.
+  //
+  // This is the "load less" lever, and it is the ONLY lever: unlike tsserver above, the
+  // extension host has no heap ceiling at any value. Established by reading the server bundle
+  // on disk rather than assumed -- it registers no heap-sizing setting, `server-main.js --help`
+  // exposes no memory option, no `remote.*` configuration property exists in the server bundle,
+  // and this build has no `server-env-setup` support. NODE_OPTIONS in particular does not work
+  // and would be actively bad: `server-main.js` deletes NODE_OPTIONS from the child environment
+  // immediately before every fork it performs, so setting it would cap the parent and every
+  // unrelated mise-node process in the pod while leaving the extension host at its default.
+  // (The one channel that does propagate is the parent's own `process.execArgv`, which the
+  // extension host inherits verbatim -- but the only injection point is a shell script inside
+  // the versioned `cli/servers/Stable-<commit>/` directory that VS Code replaces wholesale on
+  // every server upgrade, and the role rests above any share it could be given anyway.) Each entry below was checked against the extension actually
   // installed under ~/.vscode-server/extensions on a live workspace: no `main`-side use of
   // node's `fs`/`child_process`, no language-server client, no commands operating on files the
   // user hasn't opened.

--- a/private_Library/private_Application Support/private_Code/User/settings.json.tmpl
+++ b/private_Library/private_Application Support/private_Code/User/settings.json.tmpl
@@ -89,8 +89,29 @@
   },
   // Homebrew/mise symlink farms make plain (non-excluded) symlink traversal expensive.
   "search.followSymlinks": false,
-  // Cap the TypeScript server's heap instead of leaving it unbounded.
-  "typescript.tsserver.maxTsServerMemory": 2048,
+  // Cap the TypeScript server's heap instead of leaving it unbounded (default 3072 MiB).
+  // `js/ts.tsserver.maxMemory` replaces the deprecated `typescript.tsserver.maxTsServerMemory`
+  // (still honored as a fallback in the installed extension, verified against its compiled
+  // dist/extension.js, but this stops relying on that and the Settings UI deprecation nag).
+  // Both are `scope: "window"` in the extension's own configuration.json -- not MACHINE or
+  // MACHINE_OVERRIDABLE -- so, like everything else in this section, this file is the only
+  // place it can live; the remote Machine settings file would silently drop it.
+  //
+  // Value derivation: the operator wants the whole remote VS Code tree (extension host +
+  // every helper) under 2048 MiB. TypeScript spawns *two* processes that each read this same
+  // setting independently -- a full semantic server and a lighter "partialSemantic" one -- so
+  // this is a per-process ceiling, not a combined one; a pathological workspace can drive both
+  // toward it at once. 768 sits well above both processes' measured resting PSS on a live
+  // workspace (~142 MiB / ~112 MiB), leaving real headroom for a genuinely large project, while
+  // no longer leaving tsserver free to claim most of the 2048 MiB envelope by itself the way the
+  // previous 2048 setting effectively could (2 x 2048 = 4096, already over budget alone). Cost:
+  // on a large enough TypeScript project this trades an unbounded tsserver for a V8 heap OOM
+  // that the extension host catches and restarts tsserver from -- a visible but recoverable
+  // failure, not silent data loss. It is not a guarantee the whole tree fits 2048 MiB: most of
+  // that tree (extension host, file watcher, pty host, the JSON/Markdown/TOML language servers)
+  // exposes no heap-ceiling setting at all -- see remote.extensionKind below for the lever that
+  // actually shrinks the extension host, and dotfiles#772 for the rest of that story.
+  "js/ts.tsserver.maxMemory": 768,
   "typescript.disableAutomaticTypeAcquisition": true,
   // Reduce the git extension's background repository scanning.
   "git.autoRepositoryDetection": "openEditors",
@@ -114,12 +135,32 @@
   "remote.SSH.remotePlatform": {
     "coder-vscode.coder.{{ (bitwardenSecrets "288eeda0-d57f-4a91-8651-b2090163ecc0" .bwsAccessToken).value }}--{{ .coderUsername }}--{{ .coderUsername }}.main": "linux"
   },
-  // APPLICATION/WINDOW-scoped in VS Code's own configuration registry (never MACHINE or
+  // APPLICATION-scoped in VS Code's own configuration registry (never MACHINE or
   // MACHINE_OVERRIDABLE), so it must live in this file -- the remote Machine settings file
   // parses only [MACHINE, MACHINE_OVERRIDABLE] scopes and silently drops anything else.
+  //
+  // Pins extensions that do no workspace-filesystem or child-process work to the client (UI)
+  // extension host instead of the remote one, so their code never runs on the remote at all --
+  // the extension host is the tree's biggest, most volatile process (685-738 MiB PSS observed,
+  // climbing over time) precisely because of what it loads, so this is the "load less" lever
+  // rather than a heap ceiling. Each entry below was checked against the extension actually
+  // installed under ~/.vscode-server/extensions on a live workspace: no `main`-side use of
+  // node's `fs`/`child_process`, no language-server client, no commands operating on files the
+  // user hasn't opened.
+  //   - vscode-icons-team.vscode-icons, bierner.markdown-mermaid: pre-existing, unchanged.
+  //   - hashicorp.hcl, samuelcolvin.jinjahtml: grammar/syntax-highlighting only (`contributes`
+  //     is just `languages`/`grammars`[/`breakpoints` metadata for jinjahtml, not an actual
+  //     debug adapter]); confirmed no LSP client or fs/child_process usage in either's source.
+  // Considered and left on the remote (default, unset here): davidanson.vscode-markdownlint --
+  // it contributes a `markdownlint.lintWorkspace` command that walks the whole workspace tree,
+  // which is exactly the "real work against the workspace filesystem" case this lever is not
+  // for. tamasfe.even-better-toml already declares its own `extensionKind: ["workspace"]` for
+  // the same reason (it validates TOML against the real workspace, e.g. Cargo.lock/uv.lock).
   "remote.extensionKind": {
     "vscode-icons-team.vscode-icons": ["ui"],
-    "bierner.markdown-mermaid": ["ui"]
+    "bierner.markdown-mermaid": ["ui"],
+    "hashicorp.hcl": ["ui"],
+    "samuelcolvin.jinjahtml": ["ui"]
   },
   "remote.SSH.defaultExtensions": [
     "bierner.markdown-mermaid",

--- a/private_Library/private_Application Support/private_Code/User/settings.json.tmpl
+++ b/private_Library/private_Application Support/private_Code/User/settings.json.tmpl
@@ -106,11 +106,29 @@
   // macOS projects included, not just the remote workspace.
   //
   // Value. There is exactly one process class in the remote tree with a heap knob, and this is
-  // it; the extension host, file watcher, pty host and the JSON/Markdown/TOML language servers
-  // have none at any value (see remote.extensionKind below, which is the only lever that
-  // shrinks the extension host). TypeScript spawns *two* processes that each read this setting
-  // independently -- a full semantic server and a lighter "partialSemantic" one -- so it is a
-  // per-process ceiling, not a combined one.
+  // it. The extension host, file watcher, pty host and the JSON/Markdown language servers expose
+  // nothing at any value (see remote.extensionKind below, which is the only lever that shrinks
+  // the extension host). The TOML server is the one exception to that, and it is named here
+  // because the exception turns out to be useless rather than absent: tamasfe.even-better-toml
+  // does expose levers -- `evenBetterToml.taplo.environment` injects arbitrary env into the
+  // forked bundled server, and `taplo.bundled: false` + `taplo.path` substitutes the binary
+  // outright -- but nothing reachable through them bounds what actually grows there. Measured
+  // on a live workspace, that process's 274 MiB PSS is ~99 MiB of native malloc `[heap]` plus
+  // ~14 MiB of rwxp JIT code -- 41% of the process that no V8 flag can reach at any value --
+  // with the ~160 MiB remainder split between V8's managed heap and WASM linear memory in
+  // proportions smaps cannot separate (taplo is Rust compiled to WASM, whose linear memory is
+  // an ArrayBuffer backing store outside the old space). Since `--max-old-space-size` bounds
+  // only the old space, a ceiling there cannot bound this process below its share however low
+  // it is set: NODE_OPTIONS by that route is inert, not merely leaky. Recorded so this does
+  // not have to be re-derived from a blanket "no lever exists" claim.
+  //
+  // TypeScript spawns *two* processes that each read this setting independently -- a full
+  // semantic server and a lighter "partialSemantic" one -- so it is a per-process ceiling, not
+  // a combined one. `js/ts.tsserver.useSyntaxServer: "never"` would collapse the pair into a
+  // single process and is the only way to make the ceiling combined; deliberately not set,
+  // because the two rest at 112/141 MiB against a 320 MiB share so there is nothing to buy,
+  // and the cost is that syntax-only work (folding, outline, in-file rename) then queues behind
+  // semantic work.
   //
   // 768 is deliberately NOT low enough to fire before the workspace template's memory watchdog,
   // and that ordering is a decision rather than an oversight. The watchdog gives tsserver a
@@ -197,8 +215,10 @@
   // (The one channel that does propagate is the parent's own `process.execArgv`, which the
   // extension host inherits verbatim -- but the only injection point is a shell script inside
   // the versioned `cli/servers/Stable-<commit>/` directory that VS Code replaces wholesale on
-  // every server upgrade, and the role rests above any share it could be given anyway.) Each entry below was checked against the extension actually
-  // installed under ~/.vscode-server/extensions on a live workspace: no `main`-side use of
+  // every server upgrade, and the role rests above any share it could be given anyway.)
+  //
+  // Each entry below was checked against the extension actually installed under
+  // ~/.vscode-server/extensions on a live workspace: no `main`-side use of
   // node's `fs`/`child_process`, no language-server client, no commands operating on files the
   // user hasn't opened.
   //   - vscode-icons-team.vscode-icons, bierner.markdown-mermaid: pre-existing, unchanged.


### PR DESCRIPTION
## Summary

Follow-up to #773 / #772, paired with `ppat/coder#884` (the 2048 MiB envelope and per-role shares) and `ppat/coder#886` (which records the same derivation from the template side). Two settings changed, both in the Mac client User settings file only:

- **`typescript.tsserver.maxTsServerMemory` → `js/ts.tsserver.maxMemory`, 2048 → 768.** The old key is deprecated; the new one is what `readMaxTsServerMemory()` in the installed extension's compiled `dist/extension.js` reads first, with the old key as its `fallbackSubSectionNameOverride`. The old *value* was also wrong for the topology: TypeScript spawns **two** tsserver processes that each read this setting independently, so 2048 let tsserver alone sanction 4096 MiB against a 2048 MiB envelope.
- **`remote.extensionKind`: added `hashicorp.hcl` and `samuelcolvin.jinjahtml`** alongside the existing `vscode-icons-team.vscode-icons` / `bierner.markdown-mermaid`. Both are grammar/syntax-highlighting only — no LSP client, no `fs`/`child_process` use — confirmed against the extensions installed under `~/.vscode-server/extensions` on a live workspace. `davidanson.vscode-markdownlint` was considered and left on the remote: its `markdownlint.lintWorkspace` command does real work against the workspace filesystem.

## Why 768 is deliberately *not* low enough to fire before the watchdog

The obvious objection to this PR is that a 768 MiB ceiling against a 320 MiB watchdog share is decorative — the watchdog signals long before V8 reaches its own limit, so the cap never binds and the failure is a SIGKILL rather than the recoverable heap OOM the cap was supposed to buy. The observation is correct. The implied fix is harmful, and the second commit on this branch records why.

**The rule relating the two is additive, not a ratio.** `--max-old-space-size` bounds V8's old space; PSS additionally carries the node binary's share of file-backed pages, native allocations, external `ArrayBuffer`s and V8's new/code/large-object spaces — a remainder that is near-constant per role rather than proportional to the heap. So:

```text
peak PSS ≲ resting PSS + ceiling      ⇒      ordering needs   ceiling ≤ share − resting PSS
```

On measured resting PSS of 141 / 111 MiB against a 320 MiB share, that is **≈179 MiB**. Three independent reasons not to set it there:

1. **It is within 50 MiB of the floor.** `readMaxTsServerMemory()` clamps with `Math.max(n, 128)` — 128 MiB is the hard minimum, so 179 leaves no room to be wrong.
2. **Window scope makes it global.** Both keys are `scope: "window"` in the extension's own `package.json` (verified against the installed copy), which is why they can only live in this file — and therefore they apply to **every** VS Code window, local macOS projects included, where a 179 MiB TypeScript heap is a crash on any real project. A ceiling set too low turns a working feature into a crash loop that recurs immediately; a ceiling set too high is merely inert. That asymmetry decides it.
3. **It would not buy a more recoverable failure.** A V8 fatal heap error and an external SIGKILL arrive at the *same* handler in the extension, which shows `"The JS/TS language service crashed."` and, after five crashes in five minutes, `"The service will not be restarted."` The watchdog's ten-minute dwell cannot reach that rate. A binding heap ceiling on a project that legitimately needs the memory reaches it on the first few edits.

So the watchdog stays first for tsserver by design, and this ceiling keeps its original and only job: stopping a runaway tsserver from claiming the whole pod. **Cost on a large TypeScript project:** a project whose server genuinely needs more than 768 MiB of heap will crash and restart. That is real, and it is why the value is not lower.

## Correction: `NODE_OPTIONS` does not reach the rest of the tree

The previous version of this description said `NODE_OPTIONS` "would reach all of them" but could only be set from the template. **That is wrong.** `server-main.js` **deletes `NODE_OPTIONS` from the child environment immediately before every fork it performs** — one helper, called on the extension-host path and on the shared path covering the file watcher, pty host and agent host. Setting it would cap `server-main.js` itself and every unrelated mise-node process in the pod, while leaving the extension host at its default: maximum blast radius, zero effect on the target.

The only channel that propagates is the parent's own `process.execArgv`, which the extension host inherits verbatim minus `--inspect` flags — injectable only inside the versioned `cli/servers/Stable-<commit>/` directory VS Code replaces wholesale on every server upgrade. The language servers do not even inherit that: `vscode-languageclient` passes `execArgv: []` explicitly when it forks them.

Also checked and absent from this server build: any registered heap-sizing setting, any `server-main.js` CLI memory option, any `remote.*` configuration property, and `server-env-setup` support. **So `remote.extensionKind` is not the better lever for the extension host — it is the only one**, and the comment above it now says so with the checks that establish it.

## Correction: the TOML server does have levers, and they are inert

An earlier version of the comment in this file said the extension host, file watcher, pty host and the JSON/Markdown/TOML language servers "have none at any value". That is wrong for TOML, and wrong in the direction that stops the next person looking. `tamasfe.even-better-toml` exposes **`evenBetterToml.taplo.environment`** — an object setting passed straight through as `options.env` to the forked bundled server, i.e. a route to `NODE_OPTIONS` scoped to exactly one process, which is the property every other candidate in this investigation lacked — plus `taplo.bundled: false` + `taplo.path` + `taplo.extraArgs` for outright binary/argv substitution. Read from the extension's own `package.json` and `dist/extension.js` on a live workspace.

They are still not worth using, and that is now measured rather than asserted. On the live TOML server: **274 MiB PSS, of which ~99 MiB is native malloc `[heap]` and ~14 MiB is `rwxp` JIT code** — 41% of the process that no V8 flag reaches at any value — with the ~160 MiB remainder split between V8's managed heap and WASM linear memory in proportions `smaps` cannot separate. taplo is Rust compiled to WASM, and WASM linear memory is an `ArrayBuffer` backing store outside the old space. So `--max-old-space-size` cannot bring this process under its 320 MiB share however low it is set: through `taplo.environment` it is **inert, not merely leaky**. (A `taplo.path` wrapper applying an rlimit would bind — but `RLIMIT_DATA` has already been tried once in this design and landed below what an idle helper held, and this process sits at ~86% of its share having never exceeded it.)

Also recorded: **`js/ts.tsserver.useSyntaxServer: "never"`** is the one setting that would make the tsserver ceiling combined rather than per-process, by collapsing the two servers into one. Deliberately not set — the pair rests at 112/141 MiB against a 320 MiB share, so there is nothing to buy, and collapsing them queues syntax-only work (folding, outline, in-file rename) behind semantic work.

## Coverage gap (cannot verify from here)

Written from inside the live Coder workspace this targets, where `chezmoi apply` is off-limits (shared pod, live sessions) and `private_Library/**` is ignored entirely on this host (`.chezmoiignore`, `homeDir == /home/coder`), so `chezmoi diff` cannot exercise this file from here either. Verified instead with `chezmoi execute-template` (fake `bitwardenSecrets` substitution, the technique `full-apply-test.yaml` uses) confirming the template renders to valid JSONC — 66 keys, `js/ts.tsserver.maxMemory: 768`, four `remote.extensionKind` entries, deprecated key gone — plus direct inspection of the running server's processes, the server bundle, and the installed extensions' sources on that same live workspace. **This is a genuine gap: nothing here proves the settings are honoured in a real window.**

### What the operator must check (the definitive test, which cannot be run from the pod)

After `chezmoi apply` on the Mac and a window reload/reconnect:

1. **Settings UI, reconnected remote window** — search `tsserver.maxMemory`. It must show `768` **and its provenance badge must read User**, not a default. Provenance is the part that matters: VS Code silently discards settings outside a file's parsed scopes, and a value that is being dropped looks identical to one that was never set. Same for the two new `remote.extensionKind` entries.
2. **Terminal on the remote** — `pgrep -af tsserver.js` must show `--max-old-space-size=768`. If the Settings UI shows 768 but the process shows 3072, the window has simply not reloaded since the change.
3. **Help: Show Running Extensions** — `hashicorp.hcl` and `samuelcolvin.jinjahtml` must appear on the **UI** extension host, not the remote one.

**Live evidence that this is not yet in force:** both tsserver processes on this workspace still run `--max-old-space-size=3072`, VS Code's unconfigured default, on a server session that started *after* #773 merged. Since the extension does honour the old key as a fallback, that means these settings are not reaching the window at all — most likely `chezmoi apply` simply has not run on the Mac since #773. Check 1 settles it either way.

## Coupling to the template

The workspace template can never depend on dotfiles having been applied (this repo pair has been burned by exactly that). Nothing here changes that: with these settings absent — which is the state today — the watchdog behaves exactly as it does now. The extension host is over its share from birth, so the oversize rule reports it and never kills it; tsserver fits at rest and is enforced normally. `ppat/coder#886` states that coupling from the template side.

## Test plan

- [x] `pre-commit run --all-files` clean (baseline clean at base, no unrelated findings touched)
- [x] `chezmoi execute-template` on the changed file renders valid JSONC with the expected values
- [ ] Operator: `chezmoi apply` on the Mac, reload/reconnect, then checks 1–3 above

Ref: ppat/dotfiles#772, ppat/coder#884, ppat/coder#886

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197hA8JPwGMX8wufiQiy6oz
